### PR TITLE
fix: Media query should pass query to children

### DIFF
--- a/src/useStyleRegister.tsx
+++ b/src/useStyleRegister.tsx
@@ -58,6 +58,7 @@ export const parseStyle = (
   interpolation: CSSInterpolation,
   hashId?: string,
   root = true,
+  injectHash = false,
 ) => {
   let styleStr = '';
 
@@ -95,16 +96,29 @@ export const parseStyle = (
         const value = style[key];
 
         if (typeof value === 'object' && value) {
+          let subInjectHash = false;
+
           // 当成嵌套对象来处理
-          let mergedKey = key;
+          let mergedKey = key.trim();
 
           // 拆分多个选择器
-          if (root && hashId) {
-            const keys = key.split(',').map((k) => `.${hashId}${k.trim()}`);
-            mergedKey = keys.join(',');
+          if ((root || injectHash) && hashId) {
+            if (mergedKey.startsWith('@')) {
+              // 略过媒体查询，交给子节点继续插入 hashId
+              subInjectHash = true;
+            } else {
+              // 注入 hashId
+              const keys = key.split(',').map((k) => `.${hashId}${k.trim()}`);
+              mergedKey = keys.join(',');
+            }
           }
 
-          styleStr += `${mergedKey}${parseStyle(value as any, hashId, false)}`;
+          styleStr += `${mergedKey}${parseStyle(
+            value as any,
+            hashId,
+            false,
+            subInjectHash,
+          )}`;
         } else {
           // 如果是样式则直接插入
           const styleName = key.replace(

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -1,0 +1,35 @@
+import { parseStyle } from '../src/useStyleRegister';
+
+describe('util', () => {
+  describe('parseStyle', () => {
+    it('default', () => {
+      const str = parseStyle(
+        {
+          '.btn': {
+            color: 'red',
+          },
+        },
+        'hashed',
+      );
+
+      expect(str).toEqual('.hashed.btn{color:red;}');
+    });
+
+    it('media', () => {
+      const str = parseStyle(
+        {
+          '@media (max-width: 12450px)': {
+            '.btn': {
+              color: 'red',
+            },
+          },
+        },
+        'hashed',
+      );
+
+      expect(str).toEqual(
+        '@media (max-width: 12450px){.hashed.btn{color:red;}}',
+      );
+    });
+  });
+});


### PR DESCRIPTION
FIX:
```less
@media (max-width: 12450px) {
  .btn {
    color: red;
  }
}
```

to be
```less
.hashed@media (max-width: 12450px) {
  .btn {
    color: red;
  }
}
```

which should be

```less
@media (max-width: 12450px) {
  .hashed.btn {
    color: red;
  }
}
```