### PR TITLE
refactor: patch diff hash in dev

### DIFF
--- a/src/useCacheToken.tsx
+++ b/src/useCacheToken.tsx
@@ -10,7 +10,9 @@ const EMPTY_OVERRIDE = {};
 // Generate different prefix to make user selector break in production env.
 // This helps developer not to do style override directly on the hash id.
 const hashPrefix =
-  process.env.NODE_ENV !== 'production' ? 'css-dev-only-do-not-use' : 'css';
+  process.env.NODE_ENV !== 'production'
+    ? 'css-dev-only-do-not-override'
+    : 'css';
 
 export interface Option<DerivativeToken> {
   /**

--- a/src/useCacheToken.tsx
+++ b/src/useCacheToken.tsx
@@ -7,6 +7,11 @@ import { flattenToken, token2key } from './util';
 
 const EMPTY_OVERRIDE = {};
 
+// Generate different prefix to make user selector break in production env.
+// This helps developer not to do style override directly on the hash id.
+const hashPrefix =
+  process.env.NODE_ENV !== 'production' ? 'css-dev-only-do-not-use' : 'css';
+
 export interface Option<DerivativeToken> {
   /**
    * Generate token with salt.
@@ -116,7 +121,7 @@ export default function useCacheToken<
       mergedDerivativeToken._tokenKey = tokenKey;
       recordCleanToken(tokenKey);
 
-      const hashId = `css-${hash(tokenKey)}`;
+      const hashId = `${hashPrefix}-${hash(tokenKey)}`;
       mergedDerivativeToken._hashId = hashId; // Not used
 
       return [mergedDerivativeToken, hashId];

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -215,8 +215,8 @@ describe('csssinjs', () => {
     expect(styles).toHaveLength(1);
 
     const style = styles[0];
-    expect(style.innerHTML).toContain('.css-dev-only-do-not-use-6dmvpu.a');
-    expect(style.innerHTML).toContain('.css-dev-only-do-not-use-6dmvpu.b');
+    expect(style.innerHTML).toContain('.css-dev-only-do-not-override-6dmvpu.a');
+    expect(style.innerHTML).toContain('.css-dev-only-do-not-override-6dmvpu.b');
 
     unmount();
   });

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -215,8 +215,8 @@ describe('csssinjs', () => {
     expect(styles).toHaveLength(1);
 
     const style = styles[0];
-    expect(style.innerHTML).toContain('.css-6dmvpu.a');
-    expect(style.innerHTML).toContain('.css-6dmvpu.b');
+    expect(style.innerHTML).toContain('.css-dev-only-do-not-use-6dmvpu.a');
+    expect(style.innerHTML).toContain('.css-dev-only-do-not-use-6dmvpu.b');
 
     unmount();
   });


### PR DESCRIPTION
让开发者在开发环境如果复写 hash 样式在生产环境不会生效以协助用户不要去尝试通过覆盖 hash 达到覆盖样式效果。