### PR TITLE
fix: override order

### DIFF
--- a/docs/examples/basic.less
+++ b/docs/examples/basic.less
@@ -1,0 +1,3 @@
+.btn-override {
+  background: rgb(255, 200, 200);
+}

--- a/docs/examples/basic.tsx
+++ b/docs/examples/basic.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Button from './components/Button';
+import './basic.less';
 
 export default function App() {
   const [show, setShow] = React.useState(true);
@@ -23,6 +24,8 @@ export default function App() {
           <Button>Default</Button>
           <Button type="primary">Primary</Button>
           <Button type="ghost">Ghost</Button>
+
+          <Button className="btn-override">Override By ClassName</Button>
         </>
       )}
     </div>

--- a/src/StyleContext.tsx
+++ b/src/StyleContext.tsx
@@ -14,7 +14,8 @@ export function createCache() {
     const styles = document.body.querySelectorAll(`style[${ATTR_MARK}]`);
 
     Array.from(styles).forEach((style) => {
-      (style as any)[CSS_IN_JS_INSTANCE] ??= CSS_IN_JS_INSTANCE_ID;
+      (style as any)[CSS_IN_JS_INSTANCE] =
+        (style as any)[CSS_IN_JS_INSTANCE] || CSS_IN_JS_INSTANCE_ID;
       document.head.appendChild(style);
     });
 

--- a/src/useStyleRegister.tsx
+++ b/src/useStyleRegister.tsx
@@ -269,7 +269,10 @@ export default function useStyleRegister(
       animationStatistics = {};
 
       if (isMergedClientSide) {
-        const style = updateCSS(styleStr, styleId, { mark: ATTR_MARK });
+        const style = updateCSS(styleStr, styleId, {
+          mark: ATTR_MARK,
+          prepend: true,
+        });
 
         (style as any)[CSS_IN_JS_INSTANCE] = CSS_IN_JS_INSTANCE_ID;
 

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -389,8 +389,8 @@ describe('csssinjs', () => {
     const styles = Array.from(document.head.querySelectorAll('style'));
     expect(styles).toHaveLength(2);
 
-    expect(styles[0].innerHTML).toBe('a{color:red;}div{color:blue;}');
-    expect(styles[1].innerHTML).toBe(
+    expect(styles[1].innerHTML).toBe('a{color:red;}div{color:blue;}');
+    expect(styles[0].innerHTML).toBe(
       `.${hash} a{color:red;}.${hash} div{color:blue;}`,
     );
   });


### PR DESCRIPTION
调整时序，让 cssinjs 总是添加到 header 最前面以降低其相对于 app override style 的优先级。

resolve https://github.com/ant-design/ant-design/issues/36742