### PR TITLE
feat: support raw str for root cssobject

### DIFF
--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -153,7 +153,7 @@ export const parseStyle = (
               subInjectHash = true;
             } else {
               // 注入 hashId
-              const keys = key.split(',').map((k) => `.${hashId}${k.trim()}`);
+              const keys = key.split(',').map((k) => `${k.trim()}.${hashId}`);
               mergedKey = keys.join(',');
             }
           } else if (

--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -124,8 +124,14 @@ export const parseStyle = (
     Array.isArray(interpolation) ? interpolation : [interpolation],
   );
 
-  flattenStyleList.forEach((style) => {
-    if ((style as any)._keyframe) {
+  flattenStyleList.forEach((originStyle) => {
+    // Only root level can use raw string
+    const style: CSSObject =
+      typeof originStyle === 'string' && !root ? {} : originStyle;
+
+    if (typeof style === 'string') {
+      styleStr += `${style}\n`;
+    } else if ((style as any)._keyframe) {
       // Keyframe
       styleStr += parseKeyframes(style as unknown as Keyframes);
     } else {

--- a/tests/animation.spec.tsx
+++ b/tests/animation.spec.tsx
@@ -94,7 +94,7 @@ describe('animation', () => {
 
       const style = styles[0];
       expect(style.innerHTML).toEqual(
-        `@keyframes ${testHashId}-anim{to{transform:rotate(360deg);}}.${testHashId}.demo{animation-name:${testHashId}-anim;}`,
+        `@keyframes ${testHashId}-anim{to{transform:rotate(360deg);}}.demo.${testHashId}{animation-name:${testHashId}-anim;}`,
       );
     });
 
@@ -117,7 +117,7 @@ describe('animation', () => {
 
       const style = styles[0];
       expect(style.innerHTML).toEqual(
-        `.${testHashId}.demo{animation-name:${testHashId}-anim;}@keyframes ${testHashId}-anim{to{transform:rotate(360deg);}}`,
+        `.demo.${testHashId}{animation-name:${testHashId}-anim;}@keyframes ${testHashId}-anim{to{transform:rotate(360deg);}}`,
       );
     });
 
@@ -140,7 +140,7 @@ describe('animation', () => {
 
       const style = styles[0];
       expect(style.innerHTML).toEqual(
-        `.${testHashId}.demo{animation-name:${testHashId}-anim;}@keyframes ${testHashId}-anim{to{transform:rotate(360deg);}}`,
+        `.demo.${testHashId}{animation-name:${testHashId}-anim;}@keyframes ${testHashId}-anim{to{transform:rotate(360deg);}}`,
       );
     });
 
@@ -164,7 +164,7 @@ describe('animation', () => {
 
       const style = styles[0];
       expect(style.innerHTML).toEqual(
-        `.${testHashId}.demo{animation-name:${testHashId}-anim;}@keyframes ${testHashId}-anim{to{transform:rotate(360deg);}}`,
+        `.demo.${testHashId}{animation-name:${testHashId}-anim;}@keyframes ${testHashId}-anim{to{transform:rotate(360deg);}}`,
       );
     });
   });

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -220,8 +220,8 @@ describe('csssinjs', () => {
     expect(styles).toHaveLength(1);
 
     const style = styles[0];
-    expect(style.innerHTML).toContain('.css-dev-only-do-not-override-6dmvpu.a');
-    expect(style.innerHTML).toContain('.css-dev-only-do-not-override-6dmvpu.b');
+    expect(style.innerHTML).toContain('.a.css-dev-only-do-not-override-6dmvpu');
+    expect(style.innerHTML).toContain('.b.css-dev-only-do-not-override-6dmvpu');
 
     unmount();
   });

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -21,7 +21,7 @@ describe('util', () => {
         'hashed',
       );
 
-      expect(str).toEqual('.hashed.btn{color:red;}');
+      expect(str).toEqual('.btn.hashed{color:red;}');
     });
 
     it('media', () => {
@@ -37,7 +37,7 @@ describe('util', () => {
       );
 
       expect(str).toEqual(
-        '@media (max-width: 12450px){.hashed.btn{color:red;}}',
+        '@media (max-width: 12450px){.btn.hashed{color:red;}}',
       );
     });
 

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -1,5 +1,14 @@
 import { parseStyle } from '../src/hooks/useStyleRegister';
 
+// import { styleValidate, supportLayer } from '../util';
+jest.mock('../src/util', () => {
+  const origin = jest.requireActual('../src/util');
+  return {
+    ...origin,
+    supportLayer: () => true,
+  };
+});
+
 describe('util', () => {
   describe('parseStyle', () => {
     it('default', () => {
@@ -30,6 +39,22 @@ describe('util', () => {
       expect(str).toEqual(
         '@media (max-width: 12450px){.hashed.btn{color:red;}}',
       );
+    });
+
+    it('layer', () => {
+      const str = parseStyle(
+        [
+          {
+            p: {
+              color: 'red',
+            },
+          },
+        ],
+        'hashed',
+        'test-layer',
+      );
+
+      expect(str).toEqual('@layer test-layer {p.hashed{color:red;}}');
     });
   });
 });

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -1,6 +1,5 @@
 import { parseStyle } from '../src/hooks/useStyleRegister';
 
-// import { styleValidate, supportLayer } from '../util';
 jest.mock('../src/util', () => {
   const origin = jest.requireActual('../src/util');
   return {
@@ -41,20 +40,27 @@ describe('util', () => {
       );
     });
 
-    it('layer', () => {
-      const str = parseStyle(
-        [
-          {
-            p: {
-              color: 'red',
+    describe('layer', () => {
+      it('basic', () => {
+        const str = parseStyle(
+          [
+            {
+              p: {
+                color: 'red',
+              },
             },
-          },
-        ],
-        'hashed',
-        'test-layer',
-      );
+          ],
+          'hashed',
+          'test-layer',
+        );
 
-      expect(str).toEqual('@layer test-layer {p.hashed{color:red;}}');
+        expect(str).toEqual('@layer test-layer {p.hashed{color:red;}}');
+      });
+
+      it('raw order', () => {
+        const str = parseStyle('@layer a, b, c', 'hashed');
+        expect(str).toEqual('@layer a, b, c\n');
+      });
     });
   });
 });


### PR DESCRIPTION
如果是顶层提供 string 作为 cssinjs 配置会直接作用，以支持 layer 优先级配置。