### PR TITLE
feat: Optimize useStyleRegister parameter

### DIFF
--- a/src/hooks/useCacheToken.tsx
+++ b/src/hooks/useCacheToken.tsx
@@ -6,6 +6,7 @@ import {
   CSS_IN_JS_INSTANCE_ID,
 } from '../StyleContext';
 import type Theme from '../theme/Theme';
+import type { TokenType } from '../theme/interface';
 import useGlobalCache from './useGlobalCache';
 import { flattenToken, token2key } from '../util';
 
@@ -37,6 +38,10 @@ export interface Option<DerivativeToken> {
    */
   formatToken?: (mergedToken: any) => DerivativeToken;
 }
+
+export type CacheToken<DerivativeToken> = DerivativeToken & {
+  readonly _tokenKey: string;
+};
 
 const tokenKeys = new Map<string, number>();
 function recordCleanToken(tokenKey: string) {
@@ -82,13 +87,13 @@ function cleanTokenStyle(tokenKey: string) {
  * @returns Call Theme.getDerivativeToken(tokenObject) to get token
  */
 export default function useCacheToken<
-  DerivativeToken = object,
+  DerivativeToken = TokenType,
   DesignToken = DerivativeToken,
 >(
   theme: Theme<any, any>,
   tokens: Partial<DesignToken>[],
   option: Option<DerivativeToken> = {},
-): [DerivativeToken & { _tokenKey: string }, string] {
+): [CacheToken<DerivativeToken>, string] {
   const { salt = '', override = EMPTY_OVERRIDE, formatToken } = option;
 
   // Basic - We do basic cache here
@@ -105,9 +110,7 @@ export default function useCacheToken<
     [override],
   );
 
-  const cachedToken = useGlobalCache<
-    [DerivativeToken & { _tokenKey: string }, string]
-  >(
+  const cachedToken = useGlobalCache<[CacheToken<DerivativeToken>, string]>(
     'token',
     [salt, theme.id, tokenStr, overrideTokenStr],
     () => {

--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -18,6 +18,7 @@ import type { HashPriority } from '../StyleContext';
 import type Cache from '../Cache';
 import type { Theme } from '..';
 import type Keyframes from '../Keyframes';
+import type { TokenType } from '../theme/interface';
 import { styleValidate, supportLayer } from '../util';
 
 const isClientSide = canUseDom();
@@ -29,18 +30,18 @@ export type CSSProperties = Omit<
   'animationName'
 > & {
   animationName?:
-    | CSS.PropertiesFallback<number | string>['animationName']
-    | Keyframes;
+  | CSS.PropertiesFallback<number | string>['animationName']
+  | Keyframes;
 };
 
 export type CSSPropertiesWithMultiValues = {
   [K in keyof CSSProperties]:
-    | CSSProperties[K]
-    | Extract<CSSProperties[K], string>[]
-    | {
-        [SKIP_CHECK]: boolean;
-        value: CSSProperties[K] | Extract<CSSProperties[K], string>[];
-      };
+  | CSSProperties[K]
+  | Extract<CSSProperties[K], string>[]
+  | {
+    [SKIP_CHECK]: boolean;
+    value: CSSProperties[K] | Extract<CSSProperties[K], string>[];
+  };
 };
 
 export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };
@@ -64,7 +65,7 @@ export type CSSOthersObject = Record<string, CSSInterpolation>;
 
 export interface CSSObject
   extends CSSPropertiesWithMultiValues,
-    CSSPseudos,
+  CSSPseudos,
     CSSOthersObject {}
 
 // ============================================================================
@@ -145,11 +146,11 @@ export const parseStyle = (
     root: true,
   },
 ): [
-  parsedStr: string,
-  // Style content which should be unique on all of the style (e.g. Keyframes).
-  // Firefox will flick with same animation name when exist multiple same keyframes.
-  effectStyle: Record<string, string>,
-] => {
+    parsedStr: string,
+    // Style content which should be unique on all of the style (e.g. Keyframes).
+    // Firefox will flick with same animation name when exist multiple same keyframes.
+    effectStyle: Record<string, string>,
+  ] => {
   const { hashId, layer, path, hashPriority } = config;
   let styleStr = '';
   let effectStyle: Record<string, string> = {};
@@ -323,15 +324,14 @@ function Empty() {
 /**
  * Register a style to the global style sheet.
  */
-export default function useStyleRegister(
+export default function useStyleRegister<T extends TokenType>(
   info: {
-    theme: Theme<any, any>;
-    token: any;
+    token: T;
     path: string[];
     hashId?: string;
     layer?: string;
   },
-  styleFn: () => CSSInterpolation,
+  styleFn: (token: T) => CSSInterpolation,
 ) {
   const { token, path, hashId, layer } = info;
   const { autoClear, mock, defaultCache, hashPriority } =

--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -18,6 +18,7 @@ import type { HashPriority } from '../StyleContext';
 import type Cache from '../Cache';
 import type Keyframes from '../Keyframes';
 import type { TokenType } from '../theme/interface';
+import type { CacheToken } from './useCacheToken';
 import { styleValidate, supportLayer } from '../util';
 
 const isClientSide = canUseDom();
@@ -323,19 +324,19 @@ function Empty() {
 /**
  * Register a style to the global style sheet.
  */
-export default function useStyleRegister<T extends TokenType>(
+export default function useStyleRegister<DerivativeToken extends TokenType>(
   info: {
-    token: T;
+    token: CacheToken<DerivativeToken>;
     path: string[];
     hashId?: string;
     layer?: string;
   },
-  styleFn: (token: T) => CSSInterpolation,
+  styleFn: (token: CacheToken<DerivativeToken>) => CSSInterpolation,
 ) {
   const { token, path, hashId, layer } = info;
   const { autoClear, mock, defaultCache, hashPriority } =
     React.useContext(StyleContext);
-  const tokenKey = (token as any)._tokenKey as string;
+  const tokenKey = token._tokenKey;
 
   const fullPath = [tokenKey, ...path];
 

--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -66,7 +66,7 @@ export type CSSOthersObject = Record<string, CSSInterpolation>;
 export interface CSSObject
   extends CSSPropertiesWithMultiValues,
   CSSPseudos,
-    CSSOthersObject {}
+  CSSOthersObject { }
 
 // ============================================================================
 // ==                                 Parser                                 ==
@@ -351,7 +351,7 @@ export default function useStyleRegister<T extends TokenType>(
     fullPath,
     // Create cache if needed
     () => {
-      const styleObj = styleFn();
+      const styleObj = styleFn(token);
       const [parsedStyle, effectStyle] = parseStyle(styleObj, {
         hashId,
         hashPriority,

--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -16,7 +16,6 @@ import StyleContext, {
 } from '../StyleContext';
 import type { HashPriority } from '../StyleContext';
 import type Cache from '../Cache';
-import type { Theme } from '..';
 import type Keyframes from '../Keyframes';
 import type { TokenType } from '../theme/interface';
 import { styleValidate, supportLayer } from '../util';
@@ -30,18 +29,18 @@ export type CSSProperties = Omit<
   'animationName'
 > & {
   animationName?:
-  | CSS.PropertiesFallback<number | string>['animationName']
-  | Keyframes;
+    | CSS.PropertiesFallback<number | string>['animationName']
+    | Keyframes;
 };
 
 export type CSSPropertiesWithMultiValues = {
   [K in keyof CSSProperties]:
-  | CSSProperties[K]
-  | Extract<CSSProperties[K], string>[]
-  | {
-    [SKIP_CHECK]: boolean;
-    value: CSSProperties[K] | Extract<CSSProperties[K], string>[];
-  };
+    | CSSProperties[K]
+    | Extract<CSSProperties[K], string>[]
+    | {
+        [SKIP_CHECK]: boolean;
+        value: CSSProperties[K] | Extract<CSSProperties[K], string>[];
+      };
 };
 
 export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };
@@ -65,8 +64,8 @@ export type CSSOthersObject = Record<string, CSSInterpolation>;
 
 export interface CSSObject
   extends CSSPropertiesWithMultiValues,
-  CSSPseudos,
-  CSSOthersObject { }
+    CSSPseudos,
+    CSSOthersObject {}
 
 // ============================================================================
 // ==                                 Parser                                 ==
@@ -146,11 +145,11 @@ export const parseStyle = (
     root: true,
   },
 ): [
-    parsedStr: string,
-    // Style content which should be unique on all of the style (e.g. Keyframes).
-    // Firefox will flick with same animation name when exist multiple same keyframes.
-    effectStyle: Record<string, string>,
-  ] => {
+  parsedStr: string,
+  // Style content which should be unique on all of the style (e.g. Keyframes).
+  // Firefox will flick with same animation name when exist multiple same keyframes.
+  effectStyle: Record<string, string>,
+] => {
   const { hashId, layer, path, hashPriority } = config;
   let styleStr = '';
   let effectStyle: Record<string, string> = {};
@@ -336,7 +335,7 @@ export default function useStyleRegister<T extends TokenType>(
   const { token, path, hashId, layer } = info;
   const { autoClear, mock, defaultCache, hashPriority } =
     React.useContext(StyleContext);
-  const tokenKey = token._tokenKey as string;
+  const tokenKey = (token as any)._tokenKey as string;
 
   const fullPath = [tokenKey, ...path];
 


### PR DESCRIPTION
优化 useStyleRegister 参数和回调

`info` 中的 `theme` 并未使用，可以删除
增加泛型支持，并在 `styleFn` 中传入 `token`