### PR TITLE
fix: css transformer should not split calc

### DIFF
--- a/src/transformers/legacyLogicalProperties.ts
+++ b/src/transformers/legacyLogicalProperties.ts
@@ -6,7 +6,29 @@ function splitValues(value: string | number) {
     return [value];
   }
 
-  return String(value).split(/\s+/);
+  const splitStyle = String(value).split(/\s+/);
+
+  // Combine styles split in brackets, like `calc(1px + 2px)`
+  let temp = '';
+  let brackets = 0;
+  return splitStyle.reduce<string[]>((list, item) => {
+    if (item.includes('(')) {
+      temp += item;
+      brackets += item.split('(').length - 1;
+    } else if (item.includes(')')) {
+      temp += item;
+      brackets -= item.split(')').length - 1;
+      if (brackets === 0) {
+        list.push(temp);
+        temp = '';
+      }
+    } else if (brackets > 0) {
+      temp += item;
+    } else {
+      list.push(item);
+    }
+    return list;
+  }, []);
 }
 
 type MatchValue = string[] & {
@@ -126,7 +148,9 @@ const transform: Transformer = {
         } else if (matchValue.length === 4) {
           // Handle like `inset` => `top` & `right` & `bottom` & `left`
           matchValue.forEach((matchKey, index) => {
-            clone[matchKey] = skipCheck(values[index] ?? values[index - 2] ?? values[0]);
+            clone[matchKey] = skipCheck(
+              values[index] ?? values[index - 2] ?? values[0],
+            );
           });
         } else {
           clone[key] = value;

--- a/tests/transform.spec.tsx
+++ b/tests/transform.spec.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react';
 import { render } from '@testing-library/react';
-import {
-  useStyleRegister,
-  createTheme,
-  StyleProvider,
-  createCache,
-  legacyLogicalPropertiesTransformer,
-} from '../src';
+import * as React from 'react';
 import type { CSSInterpolation } from '../src';
+import {
+  createCache,
+  createTheme,
+  legacyLogicalPropertiesTransformer,
+  StyleProvider,
+  useStyleRegister,
+} from '../src';
 // import { getStyleText } from './util';
 
 describe('transform', () => {
@@ -122,6 +122,27 @@ describe('transform', () => {
         borderLeft: '3px solid yellow',
         borderRight: '2px solid green',
         borderTopLeftRadius: '4px',
+      });
+    });
+
+    it('should not split calc', () => {
+      const { container } = render(
+        <Wrapper
+          css={{
+            '.box': {
+              marginBlock: 'calc(2px + 3px)',
+              marginInline: 'calc(2px + 1px)',
+              marginInlineEnd: '3px',
+            },
+          }}
+        />,
+      );
+
+      expect(container.querySelector('.box')).toHaveStyle({
+        marginTop: 'calc(2px + 3px)',
+        marginBottom: 'calc(2px + 3px)',
+        marginLeft: 'calc(2px + 1px)',
+        marginRight: '3px',
       });
     });
   });


### PR DESCRIPTION
split 本来是为了这种情况存在的：`paddingInline: 2px 4px` 会转换成 `paddingLeft: 2px; paddingRight: 4px`。
简单的 `split(/\s+/)` 会将 `calc` 错误地分离。

其实还有更复杂的情况，比如圆角会有用 `/` 的情况。antd 中没有遇到，有问题再处理。

close https://github.com/ant-design/ant-design/issues/39881
close https://github.com/ant-design/ant-design/issues/39882