### PR TITLE
feat: StyleProvider support `linters`

### DIFF
--- a/src/StyleContext.tsx
+++ b/src/StyleContext.tsx
@@ -1,7 +1,8 @@
-import * as React from 'react';
 import useMemo from 'rc-util/lib/hooks/useMemo';
 import isEqual from 'rc-util/lib/isEqual';
+import * as React from 'react';
 import CacheEntity from './Cache';
+import type { Linter } from './linters/interface';
 import type { Transformer } from './transformers/interface';
 
 export const ATTR_TOKEN = 'data-token-hash';
@@ -65,6 +66,12 @@ export interface StyleContextProps {
   ssrInline?: boolean;
   /** Transform css before inject in document. Please note that `transformers` do not support dynamic update */
   transformers?: Transformer[];
+  /**
+   * Linters to lint css before inject in document.
+   * Styles will be linted after transforming.
+   * Please note that `linters` do not support dynamic update.
+   */
+  linters?: Linter[];
 }
 
 const StyleContext = React.createContext<StyleContextProps>({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
-import useStyleRegister, { extractStyle } from './hooks/useStyleRegister';
-import type { CSSObject, CSSInterpolation } from './hooks/useStyleRegister';
 import useCacheToken from './hooks/useCacheToken';
-import { StyleProvider, createCache } from './StyleContext';
+import type { CSSInterpolation, CSSObject } from './hooks/useStyleRegister';
+import useStyleRegister, { extractStyle } from './hooks/useStyleRegister';
 import Keyframes from './Keyframes';
-import type { TokenType, DerivativeFunc } from './theme';
+import type { Linter } from './linters';
+import { logicalPropertiesLinter } from './linters';
+import { createCache, StyleProvider } from './StyleContext';
+import type { DerivativeFunc, TokenType } from './theme';
 import { createTheme, Theme } from './theme';
-import legacyLogicalPropertiesTransformer from './transformers/legacyLogicalProperties';
 import type { Transformer } from './transformers/interface';
+import legacyLogicalPropertiesTransformer from './transformers/legacyLogicalProperties';
 
 export {
   Theme,
@@ -20,12 +22,15 @@ export {
 
   // Transformer
   legacyLogicalPropertiesTransformer,
-};
 
+  // Linters
+  logicalPropertiesLinter,
+};
 export type {
   TokenType,
   CSSObject,
   CSSInterpolation,
   DerivativeFunc,
   Transformer,
+  Linter,
 };

--- a/src/linters/contentQuotesLinter.ts
+++ b/src/linters/contentQuotesLinter.ts
@@ -1,0 +1,25 @@
+import type { Linter } from './interface';
+import { lintWarning } from './utils';
+
+const linter: Linter = (key, value, info) => {
+  if (key === 'content') {
+    // From emotion: https://github.com/emotion-js/emotion/blob/main/packages/serialize/src/index.js#L63
+    const contentValuePattern =
+      /(attr|counters?|url|(((repeating-)?(linear|radial))|conic)-gradient)\(|(no-)?(open|close)-quote/;
+    const contentValues = ['normal', 'none', 'initial', 'inherit', 'unset'];
+    if (
+      typeof value !== 'string' ||
+      (contentValues.indexOf(value) === -1 &&
+        !contentValuePattern.test(value) &&
+        (value.charAt(0) !== value.charAt(value.length - 1) ||
+          (value.charAt(0) !== '"' && value.charAt(0) !== "'")))
+    ) {
+      lintWarning(
+        `You seem to be using a value for 'content' without quotes, try replacing it with \`content: '"${value}"'\`.`,
+        info,
+      );
+    }
+  }
+};
+
+export default linter;

--- a/src/linters/hashedAnimationLinter.ts
+++ b/src/linters/hashedAnimationLinter.ts
@@ -1,0 +1,15 @@
+import type { Linter } from './interface';
+import { lintWarning } from './utils';
+
+const linter: Linter = (key, value, info) => {
+  if (key === 'animation') {
+    if (info.hashId && value !== 'none') {
+      lintWarning(
+        `You seem to be using hashed animation '${value}', in which case 'animationName' with Keyframe as value is recommended.`,
+        info,
+      );
+    }
+  }
+};
+
+export default linter;

--- a/src/linters/index.ts
+++ b/src/linters/index.ts
@@ -1,0 +1,4 @@
+export { default as contentQuotesLinter } from './contentQuotesLinter';
+export { default as hashedAnimationLinter } from './hashedAnimationLinter';
+export type { Linter } from './interface';
+export { default as logicalPropertiesLinter } from './logicalPropertiesLinter';

--- a/src/linters/interface.ts
+++ b/src/linters/interface.ts
@@ -1,0 +1,9 @@
+export interface LinterInfo {
+  path?: string;
+  hashId?: string;
+  parentSelectors: string[];
+}
+
+export interface Linter {
+  (key: string, value: string | number, info: LinterInfo): void;
+}

--- a/src/linters/logicalPropertiesLinter.ts
+++ b/src/linters/logicalPropertiesLinter.ts
@@ -1,0 +1,88 @@
+import type { Linter } from './interface';
+import { lintWarning } from './utils';
+
+const linter: Linter = (key, value, info) => {
+  switch (key) {
+    case 'marginLeft':
+    case 'marginRight':
+    case 'paddingLeft':
+    case 'paddingRight':
+    case 'left':
+    case 'right':
+    case 'borderLeft':
+    case 'borderLeftWidth':
+    case 'borderLeftStyle':
+    case 'borderLeftColor':
+    case 'borderRight':
+    case 'borderRightWidth':
+    case 'borderRightStyle':
+    case 'borderRightColor':
+    case 'borderTopLeftRadius':
+    case 'borderTopRightRadius':
+    case 'borderBottomLeftRadius':
+    case 'borderBottomRightRadius':
+      lintWarning(
+        `You seem to be using non-logical property '${key}' which is not compatible with RTL mode. Please use logical properties and values instead. For more information: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties.`,
+        info,
+      );
+      return;
+    case 'margin':
+    case 'padding':
+    case 'borderWidth':
+    case 'borderStyle':
+      // case 'borderColor':
+      if (typeof value === 'string') {
+        const valueArr = value.split(' ').map((item) => item.trim());
+        if (valueArr.length === 4 && valueArr[1] !== valueArr[3]) {
+          lintWarning(
+            `You seem to be using '${key}' property with different left ${key} and right ${key}, which is not compatible with RTL mode. Please use logical properties and values instead. For more information: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties.`,
+            info,
+          );
+        }
+      }
+      return;
+    case 'clear':
+    case 'textAlign':
+      if (value === 'left' || value === 'right') {
+        lintWarning(
+          `You seem to be using non-logical value '${value}' of ${key}, which is not compatible with RTL mode. Please use logical properties and values instead. For more information: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties.`,
+          info,
+        );
+      }
+      return;
+    case 'borderRadius':
+      if (typeof value === 'string') {
+        const radiusGroups = value.split('/').map((item) => item.trim());
+        const invalid = radiusGroups.reduce((result, group) => {
+          if (result) {
+            return result;
+          }
+          const radiusArr = group.split(' ').map((item) => item.trim());
+          // borderRadius: '2px 4px'
+          if (radiusArr.length >= 2 && radiusArr[0] !== radiusArr[1]) {
+            return true;
+          }
+          // borderRadius: '4px 4px 2px'
+          if (radiusArr.length === 3 && radiusArr[1] !== radiusArr[2]) {
+            return true;
+          }
+          // borderRadius: '4px 4px 2px 4px'
+          if (radiusArr.length === 4 && radiusArr[2] !== radiusArr[3]) {
+            return true;
+          }
+          return result;
+        }, false);
+
+        if (invalid) {
+          lintWarning(
+            `You seem to be using non-logical value '${value}' of ${key}, which is not compatible with RTL mode. Please use logical properties and values instead. For more information: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties.`,
+            info,
+          );
+        }
+      }
+      return;
+    default:
+  }
+};
+
+export default linter;

--- a/src/linters/utils.ts
+++ b/src/linters/utils.ts
@@ -1,0 +1,15 @@
+import devWarning from 'rc-util/lib/warning';
+import { LinterInfo } from './interface';
+
+export function lintWarning(message: string, info: LinterInfo) {
+  const { path, parentSelectors } = info;
+
+  devWarning(
+    false,
+    `[Ant Design CSS-in-JS] ${path ? `Error in '${path}': ` : ''}${message}${
+      parentSelectors.length
+        ? ` Selector info: ${parentSelectors.join(' -> ')})`
+        : ''
+    }`,
+  );
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,6 @@
 import hash from '@emotion/hash';
-import devWarning from 'rc-util/lib/warning';
-import { updateCSS, removeCSS } from 'rc-util/lib/Dom/dynamicCSS';
 import canUseDom from 'rc-util/lib/Dom/canUseDom';
+import { removeCSS, updateCSS } from 'rc-util/lib/Dom/dynamicCSS';
 
 export function flattenToken(token: any) {
   let str = '';
@@ -20,134 +19,9 @@ export function flattenToken(token: any) {
 /**
  * Convert derivative token to key string
  */
-export function token2key(token: any, slat: string): string {
-  return hash(`${slat}_${flattenToken(token)}`);
+export function token2key(token: any, salt: string): string {
+  return hash(`${salt}_${flattenToken(token)}`);
 }
-
-export function warning(message: string, path?: string) {
-  devWarning(
-    false,
-    `[Ant Design CSS-in-JS] ${path ? `Error in '${path}': ` : ''}${message}`,
-  );
-}
-
-export const styleValidate = (
-  key: string,
-  value: string | number | boolean | null | undefined,
-  info: {
-    path?: string;
-    hashId?: string;
-  } = {},
-) => {
-  const { path, hashId } = info;
-  switch (key) {
-    case 'content':
-      // From emotion: https://github.com/emotion-js/emotion/blob/main/packages/serialize/src/index.js#L63
-      const contentValuePattern =
-        /(attr|counters?|url|(((repeating-)?(linear|radial))|conic)-gradient)\(|(no-)?(open|close)-quote/;
-      const contentValues = ['normal', 'none', 'initial', 'inherit', 'unset'];
-      if (
-        typeof value !== 'string' ||
-        (contentValues.indexOf(value) === -1 &&
-          !contentValuePattern.test(value) &&
-          (value.charAt(0) !== value.charAt(value.length - 1) ||
-            (value.charAt(0) !== '"' && value.charAt(0) !== "'")))
-      ) {
-        warning(
-          `You seem to be using a value for 'content' without quotes, try replacing it with \`content: '"${value}"'\``,
-          path,
-        );
-      }
-      return;
-    case 'marginLeft':
-    case 'marginRight':
-    case 'paddingLeft':
-    case 'paddingRight':
-    case 'left':
-    case 'right':
-    case 'borderLeft':
-    case 'borderLeftWidth':
-    case 'borderLeftStyle':
-    case 'borderLeftColor':
-    case 'borderRight':
-    case 'borderRightWidth':
-    case 'borderRightStyle':
-    case 'borderRightColor':
-    case 'borderTopLeftRadius':
-    case 'borderTopRightRadius':
-    case 'borderBottomLeftRadius':
-    case 'borderBottomRightRadius':
-      warning(
-        `You seem to be using non-logical property '${key}' which is not compatible with RTL mode. Please use logical properties and values instead. For more information: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties.`,
-        path,
-      );
-      return;
-    case 'margin':
-    case 'padding':
-    case 'borderWidth':
-    case 'borderStyle':
-      // case 'borderColor':
-      if (typeof value === 'string') {
-        const valueArr = value.split(' ').map((item) => item.trim());
-        if (valueArr.length === 4 && valueArr[1] !== valueArr[3]) {
-          warning(
-            `You seem to be using '${key}' property with different left ${key} and right ${key}, which is not compatible with RTL mode. Please use logical properties and values instead. For more information: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties.`,
-            path,
-          );
-        }
-      }
-      return;
-    case 'clear':
-    case 'textAlign':
-      if (value === 'left' || value === 'right') {
-        warning(
-          `You seem to be using non-logical value '${value}' of ${key}, which is not compatible with RTL mode. Please use logical properties and values instead. For more information: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties.`,
-          path,
-        );
-      }
-      return;
-    case 'borderRadius':
-      if (typeof value === 'string') {
-        const radiusGroups = value.split('/').map((item) => item.trim());
-        const invalid = radiusGroups.reduce((result, group) => {
-          if (result) {
-            return result;
-          }
-          const radiusArr = group.split(' ').map((item) => item.trim());
-          // borderRadius: '2px 4px'
-          if (radiusArr.length >= 2 && radiusArr[0] !== radiusArr[1]) {
-            return true;
-          }
-          // borderRadius: '4px 4px 2px'
-          if (radiusArr.length === 3 && radiusArr[1] !== radiusArr[2]) {
-            return true;
-          }
-          // borderRadius: '4px 4px 2px 4px'
-          if (radiusArr.length === 4 && radiusArr[2] !== radiusArr[3]) {
-            return true;
-          }
-          return result;
-        }, false);
-
-        if (invalid) {
-          warning(
-            `You seem to be using non-logical value '${value}' of ${key}, which is not compatible with RTL mode. Please use logical properties and values instead. For more information: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties.`,
-            path,
-          );
-        }
-      }
-      return;
-    case 'animation':
-      if (hashId && value !== 'none') {
-        warning(
-          `You seem to be using hashed animation '${value}', in which case 'animationName' with Keyframe as value is recommended.`,
-          path,
-        );
-      }
-    default:
-      return;
-  }
-};
 
 const layerKey = `layer-${Date.now()}-${Math.random()}`.replace(/\./g, '');
 const layerWidth = '903px';

--- a/tests/linter.spec.tsx
+++ b/tests/linter.spec.tsx
@@ -1,8 +1,9 @@
-import type { CSSObject } from '../src/useStyleRegister';
-import { Theme, useCacheToken, useStyleRegister } from '../src';
 import { render } from '@testing-library/react';
 import * as React from 'react';
+import { StyleProvider, Theme, useCacheToken, useStyleRegister } from '../src';
+import type { CSSObject } from '../src/hooks/useStyleRegister';
 import Keyframes from '../src/Keyframes';
+import { logicalPropertiesLinter } from '../src/linters';
 
 interface DesignToken {
   primaryColor: string;
@@ -62,7 +63,11 @@ describe('style warning', () => {
           ]);
           return <div />;
         };
-        render(<Demo />);
+        render(
+          <StyleProvider linters={[logicalPropertiesLinter]}>
+            <Demo />
+          </StyleProvider>,
+        );
         expect(errorSpy).toHaveBeenCalledWith(
           expect.stringContaining(
             `You seem to be using non-logical property '${prop}'`,
@@ -99,7 +104,11 @@ describe('style warning', () => {
         useStyleRegister({ theme, token, path: [prop] }, () => [genStyle()]);
         return <div />;
       };
-      render(<Demo />);
+      render(
+        <StyleProvider linters={[logicalPropertiesLinter]}>
+          <Demo />
+        </StyleProvider>,
+      );
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining(
           `You seem to be using '${prop}' property with different left ${prop} and right ${prop},`,
@@ -118,7 +127,11 @@ describe('style warning', () => {
         useStyleRegister({ theme, token, path: [prop] }, () => [genStyle()]);
         return <div />;
       };
-      render(<Demo />);
+      render(
+        <StyleProvider linters={[logicalPropertiesLinter]}>
+          <Demo />
+        </StyleProvider>,
+      );
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining(
           `You seem to be using non-logical value 'left' of ${prop},`,
@@ -146,7 +159,11 @@ describe('style warning', () => {
         );
         return <div />;
       };
-      render(<Demo />);
+      render(
+        <StyleProvider linters={[logicalPropertiesLinter]}>
+          <Demo />
+        </StyleProvider>,
+      );
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining(
           `You seem to be using non-logical value '${value}' of borderRadius`,
@@ -202,7 +219,7 @@ describe('style warning', () => {
     };
     render(<Demo />);
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('selector-in-warning -> .demo'),
+      expect.stringContaining('Selector info: .demo'),
     );
   });
 


### PR DESCRIPTION
linter 模块化，由于 logical properties 的检查并不是必要的，抽离之后由需要的引入。

`content` 和 `animation` 的检查内置。

close https://github.com/ant-design/cssinjs/issues/71