### PR TITLE
feat: extract style node to support Next.js _document.tsx render style tags

### DIFF
--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -483,3 +483,25 @@ export function extractStyle(cache: Cache) {
 
   return styleText;
 }
+
+export function extractStyleNode(cache: Cache) {
+  const styleKeys = Array.from(cache.cache.keys()).filter((key) =>
+    key.startsWith('style%'),
+  );
+
+  return styleKeys.map((key) => {
+    const [styleStr, tokenKey, styleId]: [string, string, string] =
+      cache.cache.get(key)![1];
+
+    return (
+      <style
+        key={key}
+        {...{
+          [ATTR_TOKEN]: tokenKey,
+          [ATTR_MARK]: styleId,
+        }}
+        dangerouslySetInnerHTML={{ __html: styleStr }}
+      />
+    );
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import useCacheToken from './hooks/useCacheToken';
 import type { CSSInterpolation, CSSObject } from './hooks/useStyleRegister';
-import useStyleRegister, { extractStyle } from './hooks/useStyleRegister';
+import useStyleRegister, {
+  extractStyle,
+  extractStyleNode,
+} from './hooks/useStyleRegister';
 import Keyframes from './Keyframes';
 import type { Linter } from './linters';
 import { logicalPropertiesLinter } from './linters';
@@ -19,6 +22,7 @@ export {
   StyleProvider,
   Keyframes,
   extractStyle,
+  extractStyleNode,
 
   // Transformer
   legacyLogicalPropertiesTransformer,

--- a/tests/server.spec.tsx
+++ b/tests/server.spec.tsx
@@ -1,23 +1,23 @@
+import { render } from '@testing-library/react';
 import * as React from 'react';
 import { renderToString } from 'react-dom/server';
-import { render } from '@testing-library/react';
+import type { CSSInterpolation } from '../src';
 import {
+  createCache,
+  extractStyle,
+  extractStyleNode,
+  StyleProvider,
   Theme,
   useCacheToken,
   useStyleRegister,
-  StyleProvider,
-  extractStyle,
-  createCache,
 } from '../src';
-import type { CSSInterpolation } from '../src';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import canUseDom from 'rc-util/lib/Dom/canUseDom';
+import classNames from 'classnames';
 import {
+  ATTR_MARK,
   CSS_IN_JS_INSTANCE,
   CSS_IN_JS_INSTANCE_ID,
-  ATTR_MARK,
 } from '../src/StyleContext';
-import classNames from 'classnames';
 
 interface DesignToken {
   primaryColor: string;
@@ -154,6 +154,32 @@ describe('SSR', () => {
     expect(document.head.querySelectorAll('style')).toHaveLength(2);
 
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('ssr extract style node', () => {
+    // >>> SSR
+    const cache = createCache();
+
+    const html = renderToString(
+      <StyleProvider cache={cache}>
+        <IdHolder />
+        <Box>
+          <IdHolder />
+        </Box>
+        <IdHolder />
+      </StyleProvider>,
+    );
+
+    const styleNode = extractStyleNode(cache);
+    const styleText = extractStyle(cache);
+
+    const style = renderToString(<>{styleNode}</>);
+
+    expect(html).toEqual(
+      '<div id=":R1:" class="id">:R1:</div><div class="box"><div id=":Ra:" class="id">:Ra:</div></div><div id=":R3:" class="id">:R3:</div>',
+    );
+
+    expect(style).toEqual(styleText);
   });
 
   it('default hashPriority', () => {


### PR DESCRIPTION
Next.js ssr分离style时不允许直接使用extractStyle中提供的string类型的styles, 需要以react elements的形式定义。目前存在的都是hack写法：例如https://github.com/ant-design/ant-design/issues/38767#issuecomment-1350362026

rel: https://github.com/ant-design/ant-design/issues/39891 、https://github.com/ant-design/ant-design/issues/39885

在Next.js中可以这么使用
<img width="641" alt="image" src="https://user-images.githubusercontent.com/17813559/211482611-41681fcc-29cd-4522-bef8-c2c78f8a5e0f.png">
