### PR TITLE
fix: add prefix to user-select to support ios safari,ios chrome

### DIFF
--- a/src/transformers/legacyLogicalProperties.ts
+++ b/src/transformers/legacyLogicalProperties.ts
@@ -113,6 +113,9 @@ const keyMap: Record<string, MatchValue> = {
   borderStartEndRadius: ['borderTopRightRadius'],
   borderEndStartRadius: ['borderBottomLeftRadius'],
   borderEndEndRadius: ['borderBottomRightRadius'],
+  
+  // add some prefix
+  userSelect: ['MsUserSelect', 'WebkitUserSelect', 'MozUserSelect', 'userSelect'],
 };
 
 function wrapImportantAndSkipCheck(value: string | number, important: boolean) {


### PR DESCRIPTION
add prefix to user-select to support ios safari,ios chrome

默认的 user-select  在手机上的浏览器里是不支持的，需要添加前缀