### PR TITLE
fix: doc publicPath

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -1,12 +1,16 @@
 // more config: https://d.umijs.org/config
 import { defineConfig } from 'dumi';
 
+const repo = process.env.PUBLIC_PATH || '';
+
 export default defineConfig({
   favicons: ['https://avatars0.githubusercontent.com/u/9441414?s=200&v=4'],
   themeConfig: {
     name: 'cssinjs',
     logo: 'https://avatars0.githubusercontent.com/u/9441414?s=200&v=4',
   },
+  base: `/${repo}`,
+  publicPath: `/${repo}`,
   outputPath: '.doc',
   exportStatic: {},
 });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "scripts": {
     "start": "dumi dev",
-    "docs:build": "dumi build",
+    "docs:build": "cross-env PUBLIC_PATH=cssinjs/ dumi build",
     "docs:deploy": "gh-pages -d .doc",
     "compile": "father build",
     "gh-pages": "npm run docs:build && npm run docs:deploy",


### PR DESCRIPTION
修复文档静态资源路径、路由配置，https://onlyling.github.io/cssinjs

文档本身还存在另一个问题，访问 `SSR Advanced` 后其他页面的自定义主题就会失效。