### PR TITLE
fix: transformer support calc grammar

### DIFF
--- a/docs/examples/logicalProperties.tsx
+++ b/docs/examples/logicalProperties.tsx
@@ -21,7 +21,7 @@ const Demo = () => {
         border: '1px solid #000',
         position: 'relative',
         // css logical-properties
-        paddingInline: 10,
+        paddingInline: 'calc(10px - 2px)',
         borderBlockEndWidth: 3,
         marginBlock: 10,
         borderEndEndRadius: '50%',

--- a/src/transformers/legacyLogicalProperties.ts
+++ b/src/transformers/legacyLogicalProperties.ts
@@ -16,22 +16,22 @@ function splitValues(
     .split(/\s+/);
 
   // Combine styles split in brackets, like `calc(1px + 2px)`
-  let temp = '';
+  let temp: string[] = [];
   let brackets = 0;
   return [
     splitStyle.reduce<string[]>((list, item) => {
       if (item.includes('(')) {
-        temp += item;
+        temp.push(item);
         brackets += item.split('(').length - 1;
       } else if (item.includes(')')) {
-        temp += item;
+        temp.push(item);
         brackets -= item.split(')').length - 1;
         if (brackets === 0) {
-          list.push(temp);
-          temp = '';
+          list.push(temp.join(' '));
+          temp = [];
         }
       } else if (brackets > 0) {
-        temp += item;
+        temp.push(item);
       } else {
         list.push(item);
       }


### PR DESCRIPTION
调整transform方法带括号时，使用数组进行中间信息保存，还原时添加空格