### PR TITLE
fix: Suspense will make cache counter not sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@emotion/unitless": "^0.7.5",
     "classnames": "^2.3.1",
     "csstype": "^3.0.10",
-    "rc-util": "^5.27.0",
+    "rc-util": "^5.34.1",
     "stylis": "^4.0.13"
   },
   "devDependencies": {

--- a/src/hooks/useGlobalCache.tsx
+++ b/src/hooks/useGlobalCache.tsx
@@ -1,4 +1,3 @@
-import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
 import * as React from 'react';
 import type { KeyType } from '../Cache';
 import StyleContext from '../StyleContext';
@@ -41,7 +40,7 @@ export default function useClientCache<CacheType>(
   );
 
   // Remove if no need anymore
-  useLayoutEffect(() => {
+  React.useEffect(() => {
     // It's bad to call build again in effect.
     // But we have to do this since StrictMode will call effect twice
     // which will clear cache on the first time.

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -91,31 +91,46 @@ describe('csssinjs', () => {
 
     // We will not remove style immediately,
     // but remove when second style patched.
-    it('remove old style to ensure style set only exist one', () => {
-      const getBox = (props?: BoxProps) => <Box {...props} />;
+    describe('remove old style to ensure style set only exist one', () => {
+      function test(
+        name: string,
+        wrapperFn?: (node: React.ReactElement) => React.ReactElement,
+      ) {
+        it(name, () => {
+          const getBox = (props?: BoxProps) => {
+            const box: React.ReactElement = <Box {...props} />;
 
-      const { rerender } = render(getBox());
-      expect(document.head.querySelectorAll('style')).toHaveLength(1);
+            return wrapperFn?.(box) || box;
+          };
 
-      // First change
-      rerender(
-        getBox({
-          propToken: {
-            primaryColor: 'red',
-          },
-        }),
-      );
-      expect(document.head.querySelectorAll('style')).toHaveLength(1);
+          const { rerender } = render(getBox());
+          expect(document.head.querySelectorAll('style')).toHaveLength(1);
 
-      // Second change
-      rerender(
-        getBox({
-          propToken: {
-            primaryColor: 'green',
-          },
-        }),
-      );
-      expect(document.head.querySelectorAll('style')).toHaveLength(1);
+          // First change
+          rerender(
+            getBox({
+              propToken: {
+                primaryColor: 'red',
+              },
+            }),
+          );
+          expect(document.head.querySelectorAll('style')).toHaveLength(1);
+
+          // Second change
+          rerender(
+            getBox({
+              propToken: {
+                primaryColor: 'green',
+              },
+            }),
+          );
+          expect(document.head.querySelectorAll('style')).toHaveLength(1);
+        });
+      }
+
+      test('normal');
+
+      test('StrictMode', (ele) => <React.StrictMode>{ele}</React.StrictMode>);
     });
 
     it('remove style when unmount', () => {


### PR DESCRIPTION
Origin counter is increased in `useMemo` and clear in `useEffect`.

In Suspense mode, component may call `useMemo` multiple times, which may not align with `useEffect` times. Let's all move counter into `useEffect` instead.