### PR TITLE
fix: style should regenerate when remounted

### DIFF
--- a/src/hooks/useCacheToken.tsx
+++ b/src/hooks/useCacheToken.tsx
@@ -52,6 +52,8 @@ function removeStyleTags(key: string, instanceId: string) {
   }
 }
 
+const TOKEN_THRESHOLD = 0;
+
 // Remove will check current keys first
 function cleanTokenStyle(tokenKey: string, instanceId: string) {
   tokenKeys.set(tokenKey, (tokenKeys.get(tokenKey) || 0) - 1);
@@ -63,7 +65,8 @@ function cleanTokenStyle(tokenKey: string, instanceId: string) {
     return count <= 0;
   });
 
-  if (cleanableKeyList.length < tokenKeyList.length) {
+  // Should keep tokens under threshold for not to insert style too often
+  if (tokenKeyList.length - cleanableKeyList.length > TOKEN_THRESHOLD) {
     cleanableKeyList.forEach((key) => {
       removeStyleTags(key, instanceId);
       tokenKeys.delete(key);

--- a/src/hooks/useCompatibleInsertionEffect.tsx
+++ b/src/hooks/useCompatibleInsertionEffect.tsx
@@ -16,6 +16,12 @@ type UseCompatibleInsertionEffect = (
   deps?: React.DependencyList,
 ) => void;
 
+/**
+ * Polyfill `useInsertionEffect` for React < 18
+ * @param renderEffect will be executed in `useMemo`, and do not have callback
+ * @param effect will be executed in `useLayoutEffect`
+ * @param deps
+ */
 const useInsertionEffectPolyfill: UseCompatibleInsertionEffect = (
   renderEffect,
   effect,
@@ -25,6 +31,11 @@ const useInsertionEffectPolyfill: UseCompatibleInsertionEffect = (
   useLayoutEffect(() => effect(true), deps);
 };
 
+/**
+ * Compatible `useInsertionEffect`
+ * will use `useInsertionEffect` if React version >= 18,
+ * otherwise use `useInsertionEffectPolyfill`.
+ */
 const useCompatibleInsertionEffect: UseCompatibleInsertionEffect =
   useInsertionEffect
     ? (renderEffect, effect, deps) =>

--- a/src/hooks/useCompatibleInsertionEffect.tsx
+++ b/src/hooks/useCompatibleInsertionEffect.tsx
@@ -12,7 +12,7 @@ const { useInsertionEffect } = fullClone;
 
 type UseCompatibleInsertionEffect = (
   renderEffect: EffectCallback,
-  effect: EffectCallback,
+  effect: (polyfill?: boolean) => ReturnType<EffectCallback>,
   deps?: React.DependencyList,
 ) => void;
 
@@ -22,7 +22,7 @@ const useInsertionEffectPolyfill: UseCompatibleInsertionEffect = (
   deps,
 ) => {
   React.useMemo(renderEffect, deps);
-  useLayoutEffect(effect, deps);
+  useLayoutEffect(() => effect(true), deps);
 };
 
 const useCompatibleInsertionEffect: UseCompatibleInsertionEffect =

--- a/src/hooks/useGlobalCache.tsx
+++ b/src/hooks/useGlobalCache.tsx
@@ -55,11 +55,16 @@ export default function useGlobalCache<CacheType>(
     () => {
       onCacheEffect?.(cacheContent);
     },
-    () => {
+    (polyfill) => {
       // It's bad to call build again in effect.
       // But we have to do this since StrictMode will call effect twice
       // which will clear cache on the first time.
-      buildCache(([times, cache]) => [times + 1, cache]);
+      buildCache(([times, cache]) => {
+        if (polyfill && times === 0) {
+          onCacheEffect?.(cacheContent);
+        }
+        return [times + 1, cache];
+      });
 
       return () => {
         globalCache.update(fullPath, (prevCache) => {

--- a/tests/legacy.spec.tsx
+++ b/tests/legacy.spec.tsx
@@ -132,4 +132,29 @@ describe('legacy React version', () => {
 
     expect(styleCount).toBe(1);
   });
+
+  it('should keep style when remounted', () => {
+    const A = () => {
+      return <Box />;
+    };
+
+    const B = () => {
+      return <Box />;
+    };
+
+    const Demo = ({ show }: { show: boolean }) => {
+      return (
+        <>
+          <Box propToken={{ primaryColor: 'red' }} />
+          {show ? <A /> : <B />}
+        </>
+      );
+    };
+
+    const { rerender } = render(<Demo show={true} />);
+    expect(document.head.querySelectorAll('style')).toHaveLength(2);
+
+    rerender(<Demo show={false} />);
+    expect(document.head.querySelectorAll('style')).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
由于新渲染的组件 render 阶段要比旧组件的 unmount 阶段更早，所以在 react 17 以下会出现先插入新组件的 style 标签，再执行旧组件的卸载，最后执行新组件的 mount，计数+1。在旧组件卸载时计数实际上还没有增加，所以就回触发删除逻辑。
ref: https://codesandbox.io/s/aged-cdn-qjxmpz?file=/src/App.tsx