### PR TITLE
fix window is not defined on next.js edge runtimes

### DIFF
--- a/src/hooks/useHMR.ts
+++ b/src/hooks/useHMR.ts
@@ -13,6 +13,7 @@ export default process.env.NODE_ENV === 'production' ? useProdHMR : useDevHMR;
 // Webpack `module.hot.accept` do not support any deps update trigger
 // We have to hack handler to force mark as HRM
 if (
+  typeof window !== undefined &&
   process.env.NODE_ENV !== 'production' &&
   typeof module !== 'undefined' &&
   module &&


### PR DESCRIPTION
for more context: https://wintercg.org/
> The ultimate goal of the group is to promote runtimes supporting a comprehensive unified API surface that JavaScript developers can rely on regardless of the runtime they are using: be it browsers, servers, embedded applications, or edge runtimes. The members of the group want to provide a space to better coordinate between browser vendors and other implementors on how Web Platform APIs can be best implemented and used outside of browsers.