### PR TITLE
fix: should cleanup styles in useEffect cleanup function

### DIFF
--- a/src/hooks/useEffectCleanupRegister.ts
+++ b/src/hooks/useEffectCleanupRegister.ts
@@ -26,9 +26,7 @@ const useCleanupRegister = () => {
   React.useEffect(() => () => {
     cleanupFlag = true;
     if (effectCleanups.length) {
-      for (const fn of effectCleanups) {
-        fn();
-      }
+      effectCleanups.forEach((fn) => fn());
     }
   });
 

--- a/src/hooks/useEffectCleanupRegister.ts
+++ b/src/hooks/useEffectCleanupRegister.ts
@@ -1,0 +1,48 @@
+import { warning } from 'rc-util/lib/warning';
+import * as React from 'react';
+
+const fullClone = {
+  ...React,
+};
+const { useInsertionEffect } = fullClone;
+
+// DO NOT register functions in useEffect cleanup function, or functions that registered will never be called.
+const useCleanupRegister = () => {
+  const effectCleanups: (() => void)[] = [];
+  let cleanupFlag = false;
+  function register(fn: () => void) {
+    if (cleanupFlag) {
+      if (process.env.NODE_ENV !== 'production') {
+        warning(
+          false,
+          '[Ant Design CSS-in-JS] You are registering a cleanup function after unmount, which will not have any effect.',
+        );
+      }
+      return;
+    }
+    effectCleanups.push(fn);
+  }
+
+  React.useEffect(() => () => {
+    cleanupFlag = true;
+    if (effectCleanups.length) {
+      for (const fn of effectCleanups) {
+        fn();
+      }
+    }
+  });
+
+  return register;
+};
+
+const useRun = () => {
+  return function (fn: () => void) {
+    fn();
+  };
+};
+
+// Only enable register in React 18
+const useEffectCleanupRegister =
+  typeof useInsertionEffect !== 'undefined' ? useCleanupRegister : useRun;
+
+export default useEffectCleanupRegister;

--- a/src/hooks/useEffectCleanupRegister.ts
+++ b/src/hooks/useEffectCleanupRegister.ts
@@ -23,11 +23,15 @@ const useCleanupRegister = () => {
     effectCleanups.push(fn);
   }
 
-  React.useEffect(() => () => {
-    cleanupFlag = true;
-    if (effectCleanups.length) {
-      effectCleanups.forEach((fn) => fn());
-    }
+  React.useEffect(() => {
+    // Compatible with strict mode
+    cleanupFlag = false;
+    return () => {
+      cleanupFlag = true;
+      if (effectCleanups.length) {
+        effectCleanups.forEach((fn) => fn());
+      }
+    };
   });
 
   return register;

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import classNames from 'classnames';
 import * as React from 'react';
-import { ReactNode, StrictMode } from 'react';
+import { ReactElement, ReactNode, StrictMode } from 'react';
 import { describe, expect } from 'vitest';
 import type { CSSInterpolation, DerivativeFunc } from '../src';
 import {
@@ -626,7 +626,9 @@ describe('csssinjs', () => {
   });
 
   describe('should not cleanup token before finishing rendering', () => {
-    const test = (wrapper?: (node: ReactNode) => ReactNode) => {
+    const test = (
+      wrapper: (node: ReactElement) => ReactElement = (node) => node,
+    ) => {
       const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const genDemoStyle = (token: any): CSSInterpolation => ({
         '.box': {
@@ -671,32 +673,24 @@ describe('csssinjs', () => {
         );
       };
 
-      const { rerender } = render(
-        <StrictMode>
-          <Demo myToken="token1" />
-        </StrictMode>,
-      );
+      const { rerender } = render(wrapper(<Demo myToken="token1" />));
       const styles = Array.from(document.head.querySelectorAll('style'));
       expect(styles).toHaveLength(1);
       expect(styles[0].innerHTML).toContain('color:token1');
 
       rerender(
-        <StrictMode>
+        wrapper(
           <Demo myToken="token2">
             <Demo myToken="token1" />
-          </Demo>
-        </StrictMode>,
+          </Demo>,
+        ),
       );
       const styles2 = Array.from(document.head.querySelectorAll('style'));
       expect(styles2).toHaveLength(2);
       expect(styles2[0].innerHTML).toContain('color:token1');
       expect(styles2[1].innerHTML).toContain('color:token2');
 
-      rerender(
-        <StrictMode>
-          <Demo myToken="token1" />
-        </StrictMode>,
-      );
+      rerender(wrapper(<Demo myToken="token1" />));
       const styles3 = Array.from(document.head.querySelectorAll('style'));
       expect(styles3).toHaveLength(1);
       expect(styles3[0].innerHTML).toContain('color:token1');

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -625,7 +625,7 @@ describe('csssinjs', () => {
     expect(styles3[0].innerHTML).toContain('b1ackground:green');
   });
 
-  it.only('should not cleanup token before finishing rendering', () => {
+  it('should not cleanup token before finishing rendering', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const genDemoStyle = (token: any): CSSInterpolation => ({
       '.box': {

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -695,5 +695,6 @@ describe('csssinjs', () => {
         '[Ant Design CSS-in-JS] You are registering a cleanup function after unmount',
       ),
     );
+    spy.mockRestore();
   });
 });

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -1,17 +1,18 @@
 import { render } from '@testing-library/react';
 import classNames from 'classnames';
 import * as React from 'react';
-import type { CSSInterpolation } from '../src';
+import { ReactNode } from 'react';
+import { expect } from 'vitest';
+import type { CSSInterpolation, DerivativeFunc } from '../src';
 import {
   createCache,
+  createTheme,
   StyleProvider,
   Theme,
   useCacheToken,
   useStyleRegister,
-  createTheme
 } from '../src';
 import { ATTR_MARK, ATTR_TOKEN, CSS_IN_JS_INSTANCE } from '../src/StyleContext';
-import type { DerivativeFunc } from '../src';
 
 interface DesignToken {
   primaryColor: string;
@@ -562,22 +563,32 @@ describe('csssinjs', () => {
       },
     });
 
-    const Demo = ({myToken, theme: customTheme}: { myToken?: string, theme?: DerivativeFunc<any, any> }) => {
-      const [token, hashId] = useCacheToken<DerivativeToken>(theme, [{primaryColor: 'blue'}], {
-        salt: 'test',
-        override: {
-          myToken,
-          theme: customTheme && createTheme(customTheme)
+    const Demo = ({
+      myToken,
+      theme: customTheme,
+    }: {
+      myToken?: string;
+      theme?: DerivativeFunc<any, any>;
+    }) => {
+      const [token, hashId] = useCacheToken<DerivativeToken>(
+        theme,
+        [{ primaryColor: 'blue' }],
+        {
+          salt: 'test',
+          override: {
+            myToken,
+            theme: customTheme && createTheme(customTheme),
+          },
+          getComputedToken: (origin, override: any, myTheme) => {
+            const mergedToken = myTheme.getDerivativeToken(origin);
+            return {
+              ...mergedToken,
+              myToken: override.myToken,
+              ...(override.theme?.getDerivativeToken(mergedToken) ?? {}),
+            };
+          },
         },
-        getComputedToken: (origin, override: any, myTheme) => {
-          const mergedToken = myTheme.getDerivativeToken(origin);
-          return {
-            ...mergedToken,
-            myToken: override.myToken,
-            ...(override.theme?.getDerivativeToken(mergedToken) ?? {}),
-          }
-        }
-      });
+      );
 
       useStyleRegister(
         { theme, token, hashId, path: ['cssinjs-getComputedToken'] },
@@ -587,7 +598,7 @@ describe('csssinjs', () => {
       return <div className={classNames('box', hashId)} />;
     };
 
-    const { rerender } =render(<Demo myToken="test" />);
+    const { rerender } = render(<Demo myToken="test" />);
 
     const styles = Array.from(document.head.querySelectorAll('style'));
     expect(styles).toHaveLength(1);
@@ -601,11 +612,88 @@ describe('csssinjs', () => {
     expect(styles2[0].innerHTML).toContain('color:apple');
     expect(styles2[0].innerHTML).toContain('background:blue');
 
-    rerender(<Demo myToken="banana" theme={(origin) => ({...origin, primaryColor: 'green'})} />);
+    rerender(
+      <Demo
+        myToken="banana"
+        theme={(origin) => ({ ...origin, primaryColor: 'green' })}
+      />,
+    );
 
     const styles3 = Array.from(document.head.querySelectorAll('style'));
     expect(styles3).toHaveLength(1);
     expect(styles3[0].innerHTML).toContain('color:banana');
-    expect(styles3[0].innerHTML).toContain('background:green');
-  })
+    expect(styles3[0].innerHTML).toContain('b1ackground:green');
+  });
+
+  it.only('should not cleanup token before finishing rendering', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const genDemoStyle = (token: any): CSSInterpolation => ({
+      '.box': {
+        color: token.primaryColor,
+      },
+    });
+
+    const Style = ({ token, hashId }: { token: any; hashId: string }) => {
+      useStyleRegister(
+        {
+          theme,
+          token,
+          hashId,
+          path: ['cssinjs-cleanup-token-after-render', hashId],
+        },
+        () => [genDemoStyle(token)],
+      );
+
+      return null;
+    };
+
+    const Demo = ({
+      myToken,
+      children,
+    }: {
+      myToken?: string;
+      children?: ReactNode;
+    }) => {
+      const [token, hashId] = useCacheToken<DerivativeToken>(
+        theme,
+        [{ primaryColor: myToken }],
+        {
+          salt: 'test',
+        },
+      );
+
+      return (
+        <>
+          <Style token={token} hashId={hashId} />
+          <div className={classNames('box', hashId)}>{children}</div>
+        </>
+      );
+    };
+
+    const { rerender } = render(<Demo myToken="token1" />);
+    const styles = Array.from(document.head.querySelectorAll('style'));
+    expect(styles).toHaveLength(1);
+    expect(styles[0].innerHTML).toContain('color:token1');
+
+    rerender(
+      <Demo myToken="token2">
+        <Demo myToken="token1" />
+      </Demo>,
+    );
+    const styles2 = Array.from(document.head.querySelectorAll('style'));
+    expect(styles2).toHaveLength(2);
+    expect(styles2[0].innerHTML).toContain('color:token1');
+    expect(styles2[1].innerHTML).toContain('color:token2');
+
+    rerender(<Demo myToken="token1" />);
+    const styles3 = Array.from(document.head.querySelectorAll('style'));
+    expect(styles3).toHaveLength(1);
+    expect(styles3[0].innerHTML).toContain('color:token1');
+
+    expect(spy).not.toHaveBeenCalledWith(
+      expect.stringContaining(
+        '[Ant Design CSS-in-JS] You are registering a cleanup function after unmount',
+      ),
+    );
+  });
 });


### PR DESCRIPTION
React 18 启用 `useInsertionEffect` 时，切换主题的场景下，样式会先于 token 写入 cache 并插入 dom，因此在某些场景下（比如这个 PR 的测试用例），最新的样式会被 token 卸载清除。

解法：把清除 token 样式的逻辑全部放在 `useEffect` 的 cleanup 方法中执行，这样会保证在渲染的最后执行清除逻辑。