### PR TITLE
refactor: flattenToken use WeakMap

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -3,19 +3,28 @@ import canUseDom from 'rc-util/lib/Dom/canUseDom';
 import { removeCSS, updateCSS } from 'rc-util/lib/Dom/dynamicCSS';
 import { Theme } from './theme';
 
+// Create a cache here to avoid always loop generate
+const flattenTokenCache = new WeakMap<any, string>();
+
 export function flattenToken(token: any) {
-  let str = '';
-  Object.keys(token).forEach((key) => {
-    const value = token[key];
-    str += key;
-    if (value instanceof Theme) {
-      str += value.id;
-    } else if (value && typeof value === 'object') {
-      str += flattenToken(value);
-    } else {
-      str += value;
-    }
-  });
+  let str = flattenTokenCache.get(token) || '';
+
+  if (!str) {
+    Object.keys(token).forEach((key) => {
+      const value = token[key];
+      str += key;
+      if (value instanceof Theme) {
+        str += value.id;
+      } else if (value && typeof value === 'object') {
+        str += flattenToken(value);
+      } else {
+        str += value;
+      }
+    });
+
+    // Put in cache
+    flattenTokenCache.set(token, str);
+  }
   return str;
 }
 

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -1,7 +1,8 @@
 import { normalizeStyle, parseStyle } from '../src/hooks/useStyleRegister';
+import { flattenToken } from '../src/util';
 
-vi.mock('../src/util', () => {
-  const origin = vi.importActual('../src/util');
+vi.mock('../src/util', async () => {
+  const origin: any = await vi.importActual('../src/util');
   return {
     ...origin,
     supportLayer: () => true,
@@ -103,5 +104,26 @@ describe('util', () => {
         expect(str).toEqual('@layer a, b, c\n');
       });
     });
+  });
+
+  it('flattenToken should support cache', () => {
+    const token = {};
+
+    let checkTimes = 0;
+    Object.defineProperty(token, 'a', {
+      get() {
+        checkTimes += 1;
+        return 1;
+      },
+      enumerable: true,
+    });
+
+    // Repeat call flattenToken
+    for (let i = 0; i < 10000; i += 1) {
+      const tokenStr = flattenToken(token);
+      expect(tokenStr).toEqual('a1');
+    }
+
+    expect(checkTimes).toEqual(1);
   });
 });


### PR DESCRIPTION
For large app, flatten token for each component will repeat called multiple times. Use WeakMap to cache the result:

<img width="1310" alt="截屏2023-08-27 19 40 03" src="https://github.com/ant-design/cssinjs/assets/5378891/87b4dc61-cd9d-4602-814f-6d68380c4297">
