### PR TITLE
fix: fix memo path

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -6,13 +6,14 @@ import { Theme } from './theme';
 // Create a cache for memo concat
 type NestWeakMap<T> = WeakMap<object, NestWeakMap<T> | T>;
 const resultCache: NestWeakMap<object> = new WeakMap();
+const RESULT_VALUE = {};
 
 export function memoResult<T extends object, R>(
   callback: () => R,
   deps: T[],
 ): R {
   let current: WeakMap<any, any> = resultCache;
-  for (let i = 0; i < deps.length - 1; i += 1) {
+  for (let i = 0; i < deps.length; i += 1) {
     const dep = deps[i];
     if (!current.has(dep)) {
       current.set(dep, new WeakMap());
@@ -20,12 +21,11 @@ export function memoResult<T extends object, R>(
     current = current.get(dep)!;
   }
 
-  const lastDep = deps[deps.length - 1];
-  if (!current.has(lastDep)) {
-    current.set(lastDep, callback());
+  if (!current.has(RESULT_VALUE)) {
+    current.set(RESULT_VALUE, callback());
   }
 
-  return current.get(lastDep);
+  return current.get(RESULT_VALUE);
 }
 
 // Create a cache here to avoid always loop generate

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -1,5 +1,5 @@
 import { normalizeStyle, parseStyle } from '../src/hooks/useStyleRegister';
-import { flattenToken } from '../src/util';
+import { flattenToken, memoResult } from '../src/util';
 
 vi.mock('../src/util', async () => {
   const origin: any = await vi.importActual('../src/util');
@@ -125,5 +125,20 @@ describe('util', () => {
     }
 
     expect(checkTimes).toEqual(1);
+  });
+
+  it('memoResult with same subpath', () => {
+    const obj1 = {
+      a: 1,
+    };
+    const obj2 = {
+      b: 2,
+    };
+
+    const ret1 = memoResult(() => ({ ...obj1 }), [obj1]);
+    expect(memoResult(() => ({ ...obj1 }), [obj1])).toBe(ret1);
+
+    const ret2 = memoResult(() => ({ ...obj1, ...obj2 }), [obj1, obj2]);
+    expect(memoResult(() => ({ ...obj1, ...obj2 }), [obj1, obj2])).toBe(ret2);
   });
 });


### PR DESCRIPTION
对于嵌套主题，token 会存在递进关系：

```tsx
const tokenPath1 = [token1];
const tokenPath2 = [token1, token2];
```

这使得路径存在子集关系时，两者会冲突。添加额外的 `value` 映射对象隔离这种情况。