### PR TITLE
fix: style should not be removed when remounted

### DIFF
--- a/src/hooks/useCacheToken.tsx
+++ b/src/hooks/useCacheToken.tsx
@@ -223,8 +223,6 @@ export default function useCacheToken<
     },
     (cache) => {
       // Remove token will remove all related style
-      console.log('cleared');
-
       cleanTokenStyle(cache[0]._themeKey, instanceId);
     },
     ([token, , , cssVarsStr]) => {

--- a/src/hooks/useCacheToken.tsx
+++ b/src/hooks/useCacheToken.tsx
@@ -223,6 +223,8 @@ export default function useCacheToken<
     },
     (cache) => {
       // Remove token will remove all related style
+      console.log('cleared');
+
       cleanTokenStyle(cache[0]._themeKey, instanceId);
     },
     ([token, , , cssVarsStr]) => {

--- a/src/hooks/useGlobalCache.tsx
+++ b/src/hooks/useGlobalCache.tsx
@@ -96,7 +96,11 @@ export default function useGlobalCache<CacheType>(
 
           if (nextCount === 0) {
             // Always remove styles in useEffect callback
-            register(() => onCacheRemove?.(cache, false));
+            register(() => {
+              if (!globalCache.get(fullPath)) {
+                onCacheRemove?.(cache, false);
+              }
+            });
             return null;
           }
 

--- a/src/hooks/useGlobalCache.tsx
+++ b/src/hooks/useGlobalCache.tsx
@@ -86,6 +86,8 @@ export default function useGlobalCache<CacheType>(
         if (polyfill && times === 0) {
           onCacheEffect?.(cacheContent);
         }
+        console.log('times++', times + 1);
+
         return [times + 1, cache];
       });
 
@@ -97,7 +99,10 @@ export default function useGlobalCache<CacheType>(
           if (nextCount === 0) {
             // Always remove styles in useEffect callback
             register(() => {
-              if (!globalCache.get(fullPath)) {
+              // With polyfill, registered callback will always be called synchronously
+              // But without polyfill, it will be called in effect clean up,
+              // And by that time this cache is cleaned up.
+              if (polyfill || !globalCache.get(fullPath)) {
                 onCacheRemove?.(cache, false);
               }
             });

--- a/src/hooks/useGlobalCache.tsx
+++ b/src/hooks/useGlobalCache.tsx
@@ -86,8 +86,6 @@ export default function useGlobalCache<CacheType>(
         if (polyfill && times === 0) {
           onCacheEffect?.(cacheContent);
         }
-        console.log('times++', times + 1);
-
         return [times + 1, cache];
       });
 


### PR DESCRIPTION
修复组件重新 mount 时，插入的样式会被延后删除的问题。

事件顺序：
1. 组件卸载，将清除样式的任务放进下一次的 effect cleanup 中
2. 组件重新 mount，添加样式，发现 dom 中已存在，所以不会重复添加
3. 触发 effect cleanup，删除了已有样式，导致样式丢失。

解法：
注销样式前实时判断 cache 中是否存在。