### PR TITLE
fix: ssrInline duplicate style

### DIFF
--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -493,8 +493,9 @@ export default function useStyleRegister(
 
   return (node: React.ReactElement) => {
     let styleNode: React.ReactElement;
+    const [times] = cache.get(['style', ...fullPath]) || [0];
 
-    if (!ssrInline || isMergedClientSide || !defaultCache) {
+    if (!ssrInline || isMergedClientSide || !defaultCache || (ssrInline && !isMergedClientSide && !defaultCache && times > 1)) {
       styleNode = <Empty />;
     } else {
       styleNode = (


### PR DESCRIPTION
## 问题
在SSR场景`ssrInine={true}`导致重复的组件样式会被多次抽取打进html，导致文档的体积增大，nextjs里面无法直接使用`rendertostring/renderToNodeStream`
## 解决
利用记录次数，在服务端对于在cache中相同key对应的样式，只插入文档一次，并且利用react生命周期传递cache对象，不能使用defaultCache（次数是node的全局累计）
## 使用
```tsx
'use client';

import {StyleProvider, createCache, legacyLogicalPropertiesTransformer} from '@ant-design/cssinjs';
import dayjs from 'dayjs';
import 'dayjs/locale/zh-cn';
import {ConfigProvider, App} from 'antd';
import zhCN from 'antd/locale/zh_CN';
import {antdTheme} from '@/lib/antd/antdTheme';

dayjs.locale('zh-cn');

export default function AntdProvider({children}: {
    children: React.ReactNode;
}) {
    const render = <>{children}</>;
    const cache = createCache();

    return (
        <StyleProvider
            ssrInline={true}
            hashPriority="high"
            cache={cache}
            transformers={[legacyLogicalPropertiesTransformer]}
        >
            <ConfigProvider
                locale={zhCN}
                theme={antdTheme}
            >
                <App className="h-full">
                    {render}
                </App>
            </ConfigProvider>
        </StyleProvider>
    );
}

```