### PR TITLE
feat: add util genCalc and type AbstractCalculator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
 import type { StyleProviderProps } from './StyleContext';
 import { createCache, StyleProvider } from './StyleContext';
 import type { AbstractCalculator, DerivativeFunc, TokenType } from './theme';
-import { calc, createTheme, Theme } from './theme';
+import { createTheme, genCalc, Theme } from './theme';
 import type { Transformer } from './transformers/interface';
 import legacyLogicalPropertiesTransformer from './transformers/legacyLogicalProperties';
 import px2remTransformer from './transformers/px2rem';
@@ -46,7 +46,7 @@ export {
   // util
   token2CSSVar,
   unit,
-  calc,
+  genCalc,
 };
 export type {
   TokenType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,8 @@ import {
 } from './linters';
 import type { StyleProviderProps } from './StyleContext';
 import { createCache, StyleProvider } from './StyleContext';
-import type { DerivativeFunc, TokenType } from './theme';
-import { createTheme, Theme } from './theme';
+import type { AbstractCalculator, DerivativeFunc, TokenType } from './theme';
+import { calc, createTheme, Theme } from './theme';
 import type { Transformer } from './transformers/interface';
 import legacyLogicalPropertiesTransformer from './transformers/legacyLogicalProperties';
 import px2remTransformer from './transformers/px2rem';
@@ -46,6 +46,7 @@ export {
   // util
   token2CSSVar,
   unit,
+  calc,
 };
 export type {
   TokenType,
@@ -55,6 +56,7 @@ export type {
   Transformer,
   Linter,
   StyleProviderProps,
+  AbstractCalculator,
 };
 
 export const _experimental = {

--- a/src/theme/calc/CSSCalculator.ts
+++ b/src/theme/calc/CSSCalculator.ts
@@ -1,0 +1,110 @@
+import AbstractCalculator from './calculator';
+
+const CALC_UNIT = 'CALC_UNIT';
+
+const regexp = new RegExp(CALC_UNIT, 'g');
+
+function unit(value: string | number) {
+  if (typeof value === 'number') {
+    return `${value}${CALC_UNIT}`;
+  }
+  return value;
+}
+
+export default class CSSCalculator extends AbstractCalculator {
+  result: string = '';
+
+  unitlessCssVar: Set<string>;
+
+  lowPriority?: boolean;
+
+  constructor(
+    num: number | string | AbstractCalculator,
+    unitlessCssVar: Set<string>,
+  ) {
+    super();
+
+    const numType = typeof num;
+
+    this.unitlessCssVar = unitlessCssVar;
+
+    if (num instanceof CSSCalculator) {
+      this.result = `(${num.result})`;
+    } else if (numType === 'number') {
+      this.result = unit(num as number);
+    } else if (numType === 'string') {
+      this.result = num as string;
+    }
+  }
+
+  add(num: number | string | AbstractCalculator): this {
+    if (num instanceof CSSCalculator) {
+      this.result = `${this.result} + ${num.getResult()}`;
+    } else if (typeof num === 'number' || typeof num === 'string') {
+      this.result = `${this.result} + ${unit(num)}`;
+    }
+    this.lowPriority = true;
+    return this;
+  }
+
+  sub(num: number | string | AbstractCalculator): this {
+    if (num instanceof CSSCalculator) {
+      this.result = `${this.result} - ${num.getResult()}`;
+    } else if (typeof num === 'number' || typeof num === 'string') {
+      this.result = `${this.result} - ${unit(num)}`;
+    }
+    this.lowPriority = true;
+    return this;
+  }
+
+  mul(num: number | string | AbstractCalculator): this {
+    if (this.lowPriority) {
+      this.result = `(${this.result})`;
+    }
+    if (num instanceof CSSCalculator) {
+      this.result = `${this.result} * ${num.getResult(true)}`;
+    } else if (typeof num === 'number' || typeof num === 'string') {
+      this.result = `${this.result} * ${num}`;
+    }
+    this.lowPriority = false;
+    return this;
+  }
+
+  div(num: number | string | AbstractCalculator): this {
+    if (this.lowPriority) {
+      this.result = `(${this.result})`;
+    }
+    if (num instanceof CSSCalculator) {
+      this.result = `${this.result} / ${num.getResult(true)}`;
+    } else if (typeof num === 'number' || typeof num === 'string') {
+      this.result = `${this.result} / ${num}`;
+    }
+    this.lowPriority = false;
+    return this;
+  }
+
+  getResult(force?: boolean): string {
+    return this.lowPriority || force ? `(${this.result})` : this.result;
+  }
+
+  equal(options?: { unit?: boolean }): string {
+    const { unit: cssUnit } = options || {};
+
+    let mergedUnit: boolean = true;
+    if (typeof cssUnit === 'boolean') {
+      mergedUnit = cssUnit;
+    } else if (
+      Array.from(this.unitlessCssVar).some((cssVar) =>
+        this.result.includes(cssVar),
+      )
+    ) {
+      mergedUnit = false;
+    }
+
+    this.result = this.result.replace(regexp, mergedUnit ? 'px' : '');
+    if (typeof this.lowPriority !== 'undefined') {
+      return `calc(${this.result})`;
+    }
+    return this.result;
+  }
+}

--- a/src/theme/calc/NumCalculator.ts
+++ b/src/theme/calc/NumCalculator.ts
@@ -1,0 +1,54 @@
+import AbstractCalculator from './calculator';
+
+export default class NumCalculator extends AbstractCalculator {
+  result: number = 0;
+
+  constructor(num: number | string | AbstractCalculator) {
+    super();
+    if (num instanceof NumCalculator) {
+      this.result = num.result;
+    } else if (typeof num === 'number') {
+      this.result = num;
+    }
+  }
+
+  add(num: number | string | AbstractCalculator): this {
+    if (num instanceof NumCalculator) {
+      this.result += num.result;
+    } else if (typeof num === 'number') {
+      this.result += num;
+    }
+    return this;
+  }
+
+  sub(num: number | string | AbstractCalculator): this {
+    if (num instanceof NumCalculator) {
+      this.result -= num.result;
+    } else if (typeof num === 'number') {
+      this.result -= num;
+    }
+    return this;
+  }
+
+  mul(num: number | string | AbstractCalculator): this {
+    if (num instanceof NumCalculator) {
+      this.result *= num.result;
+    } else if (typeof num === 'number') {
+      this.result *= num;
+    }
+    return this;
+  }
+
+  div(num: number | string | AbstractCalculator): this {
+    if (num instanceof NumCalculator) {
+      this.result /= num.result;
+    } else if (typeof num === 'number') {
+      this.result /= num;
+    }
+    return this;
+  }
+
+  equal(): number {
+    return this.result;
+  }
+}

--- a/src/theme/calc/calculator.ts
+++ b/src/theme/calc/calculator.ts
@@ -1,0 +1,33 @@
+abstract class AbstractCalculator {
+  /**
+   * @descCN 计算两数的和，例如：1 + 2
+   * @descEN Calculate the sum of two numbers, e.g. 1 + 2
+   */
+  abstract add(num: number | string | AbstractCalculator): this;
+
+  /**
+   * @descCN 计算两数的差，例如：1 - 2
+   * @descEN Calculate the difference between two numbers, e.g. 1 - 2
+   */
+  abstract sub(num: number | string | AbstractCalculator): this;
+
+  /**
+   * @descCN 计算两数的积，例如：1 * 2
+   * @descEN Calculate the product of two numbers, e.g. 1 * 2
+   */
+  abstract mul(num: number | string | AbstractCalculator): this;
+
+  /**
+   * @descCN 计算两数的商，例如：1 / 2
+   * @descEN Calculate the quotient of two numbers, e.g. 1 / 2
+   */
+  abstract div(num: number | string | AbstractCalculator): this;
+
+  /**
+   * @descCN 获取计算结果
+   * @descEN Get the calculation result
+   */
+  abstract equal(options?: { unit?: boolean }): string | number;
+}
+
+export default AbstractCalculator;

--- a/src/theme/calc/index.ts
+++ b/src/theme/calc/index.ts
@@ -1,0 +1,12 @@
+import type AbstractCalculator from './calculator';
+import CSSCalculator from './CSSCalculator';
+import NumCalculator from './NumCalculator';
+
+const genCalc = (type: 'css' | 'js', unitlessCssVar: Set<string>) => {
+  const Calculator = type === 'css' ? CSSCalculator : NumCalculator;
+
+  return (num: number | string | AbstractCalculator) =>
+    new Calculator(num, unitlessCssVar);
+};
+
+export default genCalc;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,4 +1,4 @@
-export { default as calc } from './calc';
+export { default as genCalc } from './calc';
 export type { default as AbstractCalculator } from './calc/calculator';
 export { default as createTheme } from './createTheme';
 export type { DerivativeFunc, TokenType } from './interface';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,4 +1,6 @@
+export { default as calc } from './calc';
+export type { default as AbstractCalculator } from './calc/calculator';
 export { default as createTheme } from './createTheme';
+export type { DerivativeFunc, TokenType } from './interface';
 export { default as Theme } from './Theme';
 export { default as ThemeCache } from './ThemeCache';
-export type { TokenType, DerivativeFunc } from './interface';

--- a/tests/calc.spec.tsx
+++ b/tests/calc.spec.tsx
@@ -1,5 +1,5 @@
 import type { AbstractCalculator } from '../src';
-import { calc as genCalc } from '../src';
+import { genCalc } from '../src';
 
 describe('calculator', () => {
   const cases: [

--- a/tests/calc.spec.tsx
+++ b/tests/calc.spec.tsx
@@ -1,0 +1,151 @@
+import type { AbstractCalculator } from '../src';
+import { calc as genCalc } from '../src';
+
+describe('calculator', () => {
+  const cases: [
+    (
+      calc: (num: number | AbstractCalculator) => AbstractCalculator,
+    ) => string | number,
+    { js: number; css: string },
+  ][] = [
+    [
+      // 1 + 1
+      (calc) => calc(1).add(1).equal(),
+      {
+        js: 2,
+        css: 'calc(1px + 1px)',
+      },
+    ],
+    [
+      // (1 + 1) * 4
+      (calc) => calc(1).add(1).mul(4).equal(),
+      {
+        js: 8,
+        css: 'calc((1px + 1px) * 4)',
+      },
+    ],
+    [
+      // (2 + 4) / 2 - 2
+      (calc) => calc(2).add(4).div(2).sub(2).equal(),
+      {
+        js: 1,
+        css: 'calc((2px + 4px) / 2 - 2px)',
+      },
+    ],
+    [
+      // Bad case
+      // (2 + 4) / (3 - 2) - 2
+      (calc) => calc(2).add(4).div(calc(3).sub(2)).sub(2).equal(),
+      {
+        js: 4,
+        css: 'calc((2px + 4px) / (3px - 2px) - 2px)',
+      },
+    ],
+    [
+      // Bad case
+      // 2 * (2 + 3)
+      (calc) => calc(2).mul(calc(2).add(3)).equal(),
+      {
+        js: 10,
+        css: 'calc(2px * (2px + 3px))',
+      },
+    ],
+    [
+      // (1 + 2) * 3
+      (calc) => calc(calc(1).add(2)).mul(3).equal(),
+      {
+        js: 9,
+        css: 'calc((1px + 2px) * 3)',
+      },
+    ],
+    [
+      // 1 + (2 - 1)
+      (calc) => calc(1).add(calc(2).sub(1)).equal(),
+      {
+        js: 2,
+        css: 'calc(1px + (2px - 1px))',
+      },
+    ],
+    [
+      // 1 + 2 * 2
+      (calc) => calc(1).add(calc(2).mul(2)).equal(),
+      {
+        js: 5,
+        css: 'calc(1px + 2px * 2)',
+      },
+    ],
+    [
+      // 5 - (2 - 1)
+      (calc) => calc(5).sub(calc(2).sub(1)).equal(),
+      {
+        js: 4,
+        css: 'calc(5px - (2px - 1px))',
+      },
+    ],
+    [
+      // 2 * 6 / 3
+      (calc) => calc(2).mul(6).div(3).equal(),
+      {
+        js: 4,
+        css: 'calc(2px * 6 / 3)',
+      },
+    ],
+    [
+      // 6 / 3 * 2
+      (calc) => calc(6).div(3).mul(2).equal(),
+      {
+        js: 4,
+        css: 'calc(6px / 3 * 2)',
+      },
+    ],
+    [
+      // Bad case
+      // 6 / (3 * 2)
+      (calc) => calc(6).div(calc(3).mul(2)).equal(),
+      {
+        js: 1,
+        css: 'calc(6px / (3px * 2))',
+      },
+    ],
+    [
+      // 6
+      (calc) => calc(6).equal(),
+      {
+        js: 6,
+        css: '6px',
+      },
+    ],
+    [
+      // 1000 + 100 without unit
+      (calc) => calc(1000).add(100).equal({ unit: false }),
+      {
+        js: 1100,
+        css: 'calc(1000 + 100)',
+      },
+    ],
+  ];
+
+  cases.forEach(([exp, { js, css }], index) => {
+    it(`js calc ${index + 1}`, () => {
+      expect(exp(genCalc('js', new Set()))).toBe(js);
+    });
+
+    it(`css calc ${index + 1}`, () => {
+      expect(exp(genCalc('css', new Set()))).toBe(css);
+    });
+  });
+
+  it('css calc should work with string', () => {
+    const calc = genCalc('css', new Set());
+    expect(calc('var(--var1)').add('var(--var2)').equal()).toBe(
+      'calc(var(--var1) + var(--var2))',
+    );
+  });
+
+  it('css calc var should skip zIndex', () => {
+    const calc = genCalc('css', new Set(['--ant-z-index']));
+    expect(calc('var(--ant-z-index)').add(93).equal()).toBe(
+      'calc(var(--ant-z-index) + 93)',
+    );
+  });
+});


### PR DESCRIPTION
# [RFC] Migrate the genCalc util from antd repo
## Summary
`genCalc` API 由原 https://github.com/ant-design/ant-design/tree/master/components/theme/util/calc 迁移至 `@ant-design/cssinjs`

## Motivation
在 antd 中书写组件样式时，均统一使用 repo 中的 `genStyleHooks`、`mergeToken`、`genPresetColor`、`genSubStyleComponent`等 API，目前都统一存放于 https://github.com/ant-design/ant-design/tree/master/components/theme/util 目录下。

当前 antd 有类似`@ant-design/web3`、`@ant-design/x` 等生态库，在生态库中编写组件样式时目前几种选择：
1. 照搬 antd repo 中的代码至各生态库
2. 生态库内仅使用 `@ant-design/cssinjs` 简单实现类似的功能封装
3. 将可抽离的通用逻辑迁移至 `@ant-design/cssinjs` ，尽可能减少重复代码

对于方式一，并不可取，不同的库同样的代码，这会给后续的维护造成负担。

方式二，使用了当前已有的 `@ant-design/cssinjs` API，如 `useStyleRegister` 等，详见：https://github.com/ant-design/ant-design-web3/blob/main/packages/web3/src/theme/useStyle/index.ts

方式三，将通用的工具、逻辑抽离至 `@ant-design/cssinjs`，尽可能减少重复代码。该 RFC 仅迁移工具函数 `genCalc` 及其对应抽象类 `AbstractCalculator`

## API
### genCalc
``` typescript
type GenCalcType = (type: 'css' | 'js', unitlessCssVar: Set<string>) => (num: number | string | AbstractCalculator) => CSSCalculator | NumCalculator
```
### type AbstractCalculator
``` typescript
abstract class AbstractCalculator {
  /**
   * @descCN 计算两数的和，例如：1 + 2
   * @descEN Calculate the sum of two numbers, e.g. 1 + 2
   */
  abstract add(num: number | string | AbstractCalculator): this;

  /**
   * @descCN 计算两数的差，例如：1 - 2
   * @descEN Calculate the difference between two numbers, e.g. 1 - 2
   */
  abstract sub(num: number | string | AbstractCalculator): this;

  /**
   * @descCN 计算两数的积，例如：1 * 2
   * @descEN Calculate the product of two numbers, e.g. 1 * 2
   */
  abstract mul(num: number | string | AbstractCalculator): this;

  /**
   * @descCN 计算两数的商，例如：1 / 2
   * @descEN Calculate the quotient of two numbers, e.g. 1 / 2
   */
  abstract div(num: number | string | AbstractCalculator): this;

  /**
   * @descCN 获取计算结果
   * @descEN Get the calculation result
   */
  abstract equal(options?: { unit?: boolean }): string | number;
}
```
## Basic Example
### genCalc
``` typescript
import { genCalc } from '@ant-design/cssinjs';

genCalc('js', new Set());

genCalc('css', new Set());
```
### type AbstractCalculator
``` typescript
import type { AbstractCalculator } from '@ant-design/cssinjs';

```
## Unresolved questions
由于 antd 中常用API `genStyleHooks` 调用 `genSubStyleComponent` 调用 `genCalc`,迁移 `genCalc` 仅解决部分代码重复问题，后续仍需要持续优化。

另外，需要在 antd 中提 PR 对此次变更兼容。后续将补充。