### PR TITLE
fix: `removeCSS` not work with `container`

### DIFF
--- a/src/hooks/useCSSVarRegister.ts
+++ b/src/hooks/useCSSVarRegister.ts
@@ -58,7 +58,7 @@ const useCSSVarRegister = <V, T extends Record<string, V>>(
     },
     ([, , styleId]) => {
       if (isClientSide) {
-        removeCSS(styleId, { mark: ATTR_MARK });
+        removeCSS(styleId, { mark: ATTR_MARK, attachTo: container });
       }
     },
     ([, cssVarsStr, styleId]) => {


### PR DESCRIPTION
closes #189 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced CSS variable management by improving the functionality of the `removeCSS` feature, allowing more precise interaction with specific DOM containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->