### PR TITLE
fix: root selector with single &

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "classnames": "^2.3.1",
     "csstype": "^3.1.3",
     "rc-util": "^5.35.0",
-    "stylis": "^4.0.13"
+    "stylis": "^4.3.3"
   },
   "devDependencies": {
     "@ctrl/tinycolor": "^3.4.0",

--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -236,6 +236,9 @@ export const parseStyle = (
             if (mergedKey.startsWith('@')) {
               // 略过媒体查询，交给子节点继续插入 hashId
               subInjectHash = true;
+            } else if (mergedKey === '&') {
+              // 抹掉 root selector 上的单个 &
+              mergedKey = injectSelectorHash('', hashId, hashPriority);
             } else {
               // 注入 hashId
               mergedKey = injectSelectorHash(key, hashId, hashPriority);
@@ -251,7 +254,7 @@ export const parseStyle = (
             // and finally we will get `{color:red;}` as css, which is wrong.
             // So we need to remove key in root, and treat child `{ a: { color: 'red' } }` as root.
             mergedKey = '';
-            nextRoot = true;
+            nextRoot = !hashId;
           }
 
           const [parsedStr, childEffectStyle] = parseStyle(

--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -254,7 +254,7 @@ export const parseStyle = (
             // and finally we will get `{color:red;}` as css, which is wrong.
             // So we need to remove key in root, and treat child `{ a: { color: 'red' } }` as root.
             mergedKey = '';
-            nextRoot = !hashId;
+            nextRoot = true;
           }
 
           const [parsedStr, childEffectStyle] = parseStyle(

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -777,4 +777,38 @@ describe('csssinjs', () => {
       });
     });
   });
+
+  it('hash & nest style', () => {
+    const genHashStyle = (): CSSInterpolation => ({
+      '&': {
+        a: {
+          color: 'red',
+        },
+      },
+    });
+
+    const Holder = () => {
+      const [token, hashId] = useCacheToken<DerivativeToken>(theme, [], {
+        salt: 'test',
+      });
+
+      useStyleRegister({ theme, token, hashId, path: ['holder'] }, () => [
+        genHashStyle(),
+      ]);
+
+      return <div className={classNames('box', hashId)} />;
+    };
+
+    const { unmount } = render(<Holder />);
+
+    const styles = Array.from(document.head.querySelectorAll('style'));
+    expect(styles).toHaveLength(1);
+
+    const style = styles[0];
+    expect(style.innerHTML).toContain(
+      ':where(.css-dev-only-do-not-override-1ldpa3u) a{color:red;}',
+    );
+
+    unmount();
+  });
 });

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -778,7 +778,7 @@ describe('csssinjs', () => {
     });
   });
 
-  it.only('hash & nest style', () => {
+  it('hash & nest style', () => {
     const genHashStyle = (): CSSInterpolation => ({
       '&': {
         a: {

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -778,7 +778,7 @@ describe('csssinjs', () => {
     });
   });
 
-  it('hash & nest style', () => {
+  it.only('hash & nest style', () => {
     const genHashStyle = (): CSSInterpolation => ({
       '&': {
         a: {


### PR DESCRIPTION
- test: add break test
- fix: root selector with single &


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `stylis` package to improve performance and potentially introduce new features.
	- Enhanced CSS selector processing to ensure correct handling of the root selector.

- **Tests**
	- Added a new test case to verify the correct generation and application of CSS styles using a hash mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->