### PR TITLE
Fixed #197 优化useGlobalCache中频繁调用useEffectCleanupRegister导致内存过多占用的问题

### DIFF
--- a/src/hooks/useGlobalCache.tsx
+++ b/src/hooks/useGlobalCache.tsx
@@ -23,8 +23,18 @@ export default function useGlobalCache<CacheType>(
 ): CacheType {
   const { cache: globalCache } = React.useContext(StyleContext);
   const fullPath = [prefix, ...keyPath];
+
+  // 缓存fullPathStr，减少render导致的内存占用问题
   const stableFullPathStr = React.useRef(pathKey(fullPath));
-  const fullPathStr = stableFullPathStr.current;
+  const fullPathStr = React.useMemo(() => {
+    const _fullPathStr = pathKey(fullPath);
+    // 比较fullPathStr变更
+    if (_fullPathStr !== stableFullPathStr.current) {
+      stableFullPathStr.current = _fullPathStr;
+      return _fullPathStr;
+    }
+    return stableFullPathStr.current;
+  }, [fullPath]);
 
   const register = useEffectCleanupRegister([fullPathStr]);
 

--- a/src/hooks/useGlobalCache.tsx
+++ b/src/hooks/useGlobalCache.tsx
@@ -23,7 +23,8 @@ export default function useGlobalCache<CacheType>(
 ): CacheType {
   const { cache: globalCache } = React.useContext(StyleContext);
   const fullPath = [prefix, ...keyPath];
-  const fullPathStr = pathKey(fullPath);
+  const stableFullPathStr = React.useRef(pathKey(fullPath));
+  const fullPathStr = stableFullPathStr.current;
 
   const register = useEffectCleanupRegister([fullPathStr]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- 修复了 `fullPathStr` 变量在组件渲染中的不一致性问题，确保其在多个渲染之间保持稳定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->