### PR TITLE
chore: update stylis to avoid leading '&' generate invalid css

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "classnames": "^2.3.1",
     "csstype": "^3.1.3",
     "rc-util": "^5.35.0",
-    "stylis": "^4.3.3"
+    "stylis": "^4.3.4"
   },
   "devDependencies": {
     "@ctrl/tinycolor": "^3.4.0",

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -145,4 +145,25 @@ describe('util', () => {
     const ret2 = memoResult(() => ({ ...obj1, ...obj2 }), [obj1, obj2]);
     expect(memoResult(() => ({ ...obj1, ...obj2 }), [obj1, obj2])).toBe(ret2);
   });
+
+  describe('normalizeStyle', () => {
+    it('with leading &', () => {
+      const [str] = parseStyle(
+        {
+          '&.btn-variant-outline,&.btn-variant-dashed': {
+            color: 'red',
+          },
+        },
+        { hashId: 'hashed' },
+      );
+      const normalized = normalizeStyle(str);
+
+      expect(str).toEqual(
+        '.hashed&.btn-variant-outline,.hashed&.btn-variant-dashed{color:red;}',
+      );
+      expect(normalized).toEqual(
+        '.hashed.btn-variant-outline,.hashed.btn-variant-dashed{color:red;}',
+      );
+    });
+  });
 });


### PR DESCRIPTION
升级 stylis 修复 bad css 如

```css
:where(.css-ni1kz0)&.ant-btn-variant-outlined,
:where(.css-ni1kz0)&.ant-btn-variant-dashed {
  border-color: #d9d9d9;
  background: #ffffff;
}
```

stylis@v4.3.4 normalize 可以去除 `:where(.css-ni1kz0)&.ant-btn-variant-outlined` 中的 `&`

![cssinjs](https://github.com/user-attachments/assets/eefdb719-8c43-4365-a58a-c83a1d44798c)




## demo

https://codesandbox.io/p/sandbox/8vn48p?file=%2Fmain.js%3A11%2C2

在 external `react` / `react-dom` / `dayjs` / `@ant-design/cssinjs` / `antd` 后, `<antd.Button></antd.Button>` 没有边框, 是因为 `border-color`  css 不生效, 可以看动图


![cssinjs-demo](https://github.com/user-attachments/assets/13534f03-bd68-4276-ada8-f1b7024b8de5)

@ant-design/cssinjs/1.21.1/files/dist/umd/cssinjs.min.js 刚好是 stylis 4.3.3 打包的
https://unpkg.com/browse/@ant-design/cssinjs@1.21.1/package.json










<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了 `stylis` 依赖的版本，提升了样式处理的稳定性和性能。
  
- **测试**
	- 新增了 `normalizeStyle` 函数的测试套件，确保样式处理的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->