### PR TITLE
fix: 修复effect style无__cssinjs_instance__的问题

### DIFF
--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -494,11 +494,13 @@ export default function useStyleRegister(
           // ================= Inject Layer Style =================
           // Inject layer style
           effectLayerKeys.forEach((effectKey) => {
-            updateCSS(
+            const effectLayerStyle = updateCSS(
               normalizeStyle(effectStyle[effectKey]),
               `_layer-${effectKey}`,
               { ...mergedCSSConfig, prepend: true },
             );
+            // fix effect style no CSS_IN_JS_INSTANCE
+            (effectLayerStyle as any)[CSS_IN_JS_INSTANCE] = cache.instanceId;
           });
 
           // ==================== Inject Style ====================
@@ -518,11 +520,13 @@ export default function useStyleRegister(
           // ================ Inject Effect Style =================
           // Inject client side effect style
           effectRestKeys.forEach((effectKey) => {
-            updateCSS(
+            const effectRestStyle = updateCSS(
               normalizeStyle(effectStyle[effectKey]),
               `_effect-${effectKey}`,
               mergedCSSConfig,
             );
+            // fix effect style no CSS_IN_JS_INSTANCE
+            (effectRestStyle as any)[CSS_IN_JS_INSTANCE] = cache.instanceId;
           });
         }
       },


### PR DESCRIPTION
effect style在无__cssinjs_instance__属性时，可能会被赋予新的instance id，导致被插入到head中，在qiankun微前端场景下被插入到了qiankun-head中，出现异常。
![image](https://github.com/user-attachments/assets/7db4ad49-56d8-4c07-9473-c3e88370eef1)
该pr是解决这个问题。
