### PR TITLE
refactor: all flattenToken need hashed

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -35,7 +35,7 @@ const flattenTokenCache = new WeakMap<any, string>();
 /**
  * Flatten token to string, this will auto cache the result when token not change
  */
-export function flattenToken(token: any, hashed: boolean = false) {
+export function flattenToken(token: any) {
   let str = flattenTokenCache.get(token) || '';
 
   if (!str) {
@@ -45,7 +45,7 @@ export function flattenToken(token: any, hashed: boolean = false) {
       if (value instanceof Theme) {
         str += value.id;
       } else if (value && typeof value === 'object') {
-        str += flattenToken(value, hashed);
+        str += flattenToken(value);
       } else {
         str += value;
       }
@@ -53,9 +53,7 @@ export function flattenToken(token: any, hashed: boolean = false) {
 
     // https://github.com/ant-design/ant-design/issues/48386
     // Should hash the string to avoid style tag name too long
-    if (hashed) {
-      str = hash(str);
-    }
+    str = hash(str);
 
     // Put in cache
     flattenTokenCache.set(token, str);
@@ -67,7 +65,7 @@ export function flattenToken(token: any, hashed: boolean = false) {
  * Convert derivative token to key string
  */
 export function token2key(token: any, salt: string): string {
-  return hash(`${salt}_${flattenToken(token, true)}`);
+  return hash(`${salt}_${flattenToken(token)}`);
 }
 
 const randomSelectorKey = `random-${Date.now()}-${Math.random()}`.replace(

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -202,7 +202,7 @@ describe('csssinjs', () => {
     const { container } = render(<TokenShower />);
 
     // src/util.tsx - token2key func
-    expect(container.textContent).toEqual('1cpx0di');
+    expect(container.textContent).toEqual('1fs647j');
   });
 
   it('hash', () => {

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -125,7 +125,7 @@ describe('util', () => {
     // Repeat call flattenToken
     for (let i = 0; i < 10000; i += 1) {
       const tokenStr = flattenToken(token);
-      expect(tokenStr).toEqual('a1');
+      expect(tokenStr).toEqual('d9a1z5');
     }
 
     expect(checkTimes).toEqual(1);


### PR DESCRIPTION
fix https://github.com/ant-design/cssinjs/issues/197
fix https://github.com/ant-design/cssinjs/issues/188
close #198

`useGlobalCache` 需要走一遍 `useMemo` cache，deps 由于会被 React Fiber cache 导致内存占用。这里拿时间换一点空间出来，从而节省巨型页面中的内存占用情况。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 改进了令牌处理流程，确保所有扁平化的令牌都经过哈希处理，从而简化了逻辑。

- **错误修复**
  - 测试确保样式在组件的生命周期内正确应用和移除，增强了样式管理系统的健壮性。

- **文档**
  - 更新了测试用例，以反映 `flattenToken` 函数的行为变化，确保缓存机制正常工作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->