### PR TITLE
fix: cascade layer is not applied when there is no style content

### DIFF
--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -333,7 +333,11 @@ export const parseStyle = (
   if (!root) {
     styleStr = `{${styleStr}}`;
   } else if (layer) {
-    styleStr = `@layer ${layer.name} {${styleStr}}`;
+
+    // fixme: https://github.com/thysultan/stylis/pull/339
+    if (styleStr) {
+      styleStr = `@layer ${layer.name} {${styleStr}}`;
+    }
 
     if (layer.dependencies) {
       effectStyle[`@layer ${layer.name}`] = layer.dependencies

--- a/tests/layer.spec.tsx
+++ b/tests/layer.spec.tsx
@@ -66,4 +66,34 @@ describe('layer', () => {
     const styles = Array.from(document.head.querySelectorAll('style'));
     expect(styles[0].innerHTML.trim()).toEqual('@layer shared,button;');
   });
+
+  // TODO: try fix, If stylis is fixed, this case should not be needed here.
+  // https://github.com/thysultan/stylis/pull/339
+  // https://github.com/ant-design/ant-design/issues/51867
+  it('empty braces (#51867)', () => {
+    const theme = createTheme(() => ({}));
+    const Demo = () => {
+      useStyleRegister(
+        {
+          theme,
+          token: { _tokenKey: 'test' },
+          path: ['shared'],
+          layer: {
+            name: 'shared',
+          },
+        },
+        () => [],
+      );
+      return null;
+    };
+
+    render(
+      <StyleProvider layer cache={createCache()}>
+        <Demo />
+      </StyleProvider>,
+    );
+
+    const styles = Array.from(document.head.querySelectorAll('style'));
+    expect(styles[0].innerHTML.trim()).toEqual('');
+  });
 });


### PR DESCRIPTION
fix: https://github.com/ant-design/ant-design/issues/51867

 ### Solution

antd 的某些组件，比如 popover 用的 tooltips， 设置了 injectStyle 为 false， 使得 useStyleRegister 放回空样式， stylis 处理后结果刚好碰到 https://github.com/thysultan/stylis/pull/339 处理逻辑。导致多拼接了一个级联层。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增强了样式注册逻辑，确保在提供层时不会生成空的层样式。
  
- **测试**
  - 在样式注册测试中添加了新的测试用例，以验证当样式注册函数返回空数组时的行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->