### PR TITLE
fix: `removeCSS` not work with `container`

### DIFF
--- a/src/hooks/useCSSVarRegister.ts
+++ b/src/hooks/useCSSVarRegister.ts
@@ -58,7 +58,7 @@ const useCSSVarRegister = <V, T extends Record<string, V>>(
     },
     ([, , styleId]) => {
       if (isClientSide) {
-        removeCSS(styleId, { mark: ATTR_MARK });
+        removeCSS(styleId, { mark: ATTR_MARK, attachTo: container });
       }
     },
     ([, cssVarsStr, styleId]) => {

--- a/src/hooks/useCSSVarRegister.ts
+++ b/src/hooks/useCSSVarRegister.ts
@@ -35,7 +35,6 @@ const useCSSVarRegister = <V, T extends Record<string, V>>(
 ) => {
   const { key, prefix, unitless, ignore, token, scope = '' } = config;
   const {
-    autoClear,
     cache: { instanceId },
     container,
   } = useContext(StyleContext);
@@ -57,8 +56,8 @@ const useCSSVarRegister = <V, T extends Record<string, V>>(
       const styleId = uniqueHash(stylePath, cssVarsStr);
       return [mergedToken, cssVarsStr, styleId, key];
     },
-    ([, , styleId], fromHMR) => {
-      if ((fromHMR || autoClear) && isClientSide) {
+    ([, , styleId]) => {
+      if (isClientSide) {
         removeCSS(styleId, { mark: ATTR_MARK, attachTo: container });
       }
     },

--- a/src/hooks/useCSSVarRegister.ts
+++ b/src/hooks/useCSSVarRegister.ts
@@ -35,6 +35,7 @@ const useCSSVarRegister = <V, T extends Record<string, V>>(
 ) => {
   const { key, prefix, unitless, ignore, token, scope = '' } = config;
   const {
+    autoClear,
     cache: { instanceId },
     container,
   } = useContext(StyleContext);
@@ -56,8 +57,8 @@ const useCSSVarRegister = <V, T extends Record<string, V>>(
       const styleId = uniqueHash(stylePath, cssVarsStr);
       return [mergedToken, cssVarsStr, styleId, key];
     },
-    ([, , styleId]) => {
-      if (isClientSide) {
+    ([, , styleId], fromHMR) => {
+      if ((fromHMR || autoClear) && isClientSide) {
         removeCSS(styleId, { mark: ATTR_MARK, attachTo: container });
       }
     },

--- a/src/hooks/useCacheToken.tsx
+++ b/src/hooks/useCacheToken.tsx
@@ -92,15 +92,13 @@ const TOKEN_THRESHOLD = 0;
 function cleanTokenStyle(tokenKey: string, instanceId: string) {
   tokenKeys.set(tokenKey, (tokenKeys.get(tokenKey) || 0) - 1);
 
-  const tokenKeyList = Array.from(tokenKeys.keys());
-  const cleanableKeyList = tokenKeyList.filter((key) => {
-    const count = tokenKeys.get(key) || 0;
-
-    return count <= 0;
-  });
+  const cleanableKeyList = new Set<string>();
+  tokenKeys.forEach((value, key) => {
+    if (value <= 0) cleanableKeyList.add(key);
+  })
 
   // Should keep tokens under threshold for not to insert style too often
-  if (tokenKeyList.length - cleanableKeyList.length > TOKEN_THRESHOLD) {
+  if (tokenKeys.size - cleanableKeyList.size > TOKEN_THRESHOLD) {
     cleanableKeyList.forEach((key) => {
       removeStyleTags(key, instanceId);
       tokenKeys.delete(key);

--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -462,7 +462,7 @@ export default function useStyleRegister(
       // Remove cache if no need
       ([, , styleId], fromHMR) => {
         if ((fromHMR || autoClear) && isClientSide) {
-          removeCSS(styleId, { mark: ATTR_MARK, attachTo: container });
+          removeCSS(styleId, { mark: ATTR_MARK });
         }
       },
 

--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -462,7 +462,7 @@ export default function useStyleRegister(
       // Remove cache if no need
       ([, , styleId], fromHMR) => {
         if ((fromHMR || autoClear) && isClientSide) {
-          removeCSS(styleId, { mark: ATTR_MARK });
+          removeCSS(styleId, { mark: ATTR_MARK, attachTo: container });
         }
       },
 

--- a/src/hooks/useStyleRegister.tsx
+++ b/src/hooks/useStyleRegister.tsx
@@ -333,7 +333,6 @@ export const parseStyle = (
   if (!root) {
     styleStr = `{${styleStr}}`;
   } else if (layer) {
-
     // fixme: https://github.com/thysultan/stylis/pull/339
     if (styleStr) {
       styleStr = `@layer ${layer.name} {${styleStr}}`;
@@ -462,7 +461,7 @@ export default function useStyleRegister(
       // Remove cache if no need
       ([, , styleId], fromHMR) => {
         if ((fromHMR || autoClear) && isClientSide) {
-          removeCSS(styleId, { mark: ATTR_MARK });
+          removeCSS(styleId, { mark: ATTR_MARK, attachTo: container });
         }
       },
 


### PR DESCRIPTION
Co-authored-by: SakuraHentai <SakuraHentai@users.noreply.github.com>

fix #189
close #190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 优化了样式清理逻辑，确保在组件卸载时能正确移除样式并依附到指定容器中。

- **测试**
  - 新增测试用例验证组件卸载时样式的自动清理，进一步提升样式管理的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->