### PR TITLE
docs: add first render demo

### DIFF
--- a/docs/demo/first-render.md
+++ b/docs/demo/first-render.md
@@ -1,0 +1,8 @@
+---
+title: First Render
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/first-render.tsx"></code>

--- a/docs/examples/first-render.tsx
+++ b/docs/examples/first-render.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import './basic.less';
+import Button from './components/Button';
+
+const Demo = () => {
+  const renderStart = React.useRef(Date.now());
+  const [renderTime, setRenderTime] = React.useState(0);
+
+  React.useEffect(() => {
+    setRenderTime(Date.now() - renderStart.current);
+  }, []);
+
+  return (
+    <>
+      <p>Render Time: {renderTime}ms</p>
+      {Array(10000)
+        .fill(1)
+        .map((_, key) => (
+          <div key={key}>
+            <Button>Default</Button>
+            <Button type="primary">Primary</Button>
+            <Button type="ghost">Ghost</Button>
+            <Button className="btn-override">Override By ClassName</Button>
+          </div>
+        ))}
+    </>
+  );
+};
+
+export default function App() {
+  const [show, setShow] = React.useState(false);
+
+  return (
+    <div style={{ background: 'rgba(0,0,0,0.1)', padding: 16 }}>
+      <h3>默认情况下不会自动删除添加的样式</h3>
+
+      <label>
+        <input type="checkbox" checked={show} onChange={() => setShow(!show)} />
+        Show Components
+      </label>
+
+      {show && (
+        <div>
+          <Demo />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
渲染了四万个 Button，耗时 700+ ms
![image](https://github.com/user-attachments/assets/31a41339-a215-4d93-ae24-988d4d41b1f1)

可能的几个优化点：
1. findStyles。每次渲染组件都会执行 updateCSS，这里就会去 dom 遍历寻找是否有存在的 style 标签，耗时大头
2. flatternToken。每次 useToken 都会调用，里面有 hash 操作
3. spread。babel 的 pollyfill，看浏览器兼容性有 95%，不确定是否可以把产物 es 版本拉上去