### PR TITLE
perf: cache effect

### DIFF
--- a/tests/animation.spec.tsx
+++ b/tests/animation.spec.tsx
@@ -179,7 +179,7 @@ describe('animation', () => {
     });
   });
 
-  it('re-mount should not missing animation style', () => {
+  it('re-mount should not missing animation style', async () => {
     function genComp(cls: string) {
       return () => {
         const [token, hashId] = useCacheToken(theme, [baseToken], {
@@ -210,6 +210,8 @@ describe('animation', () => {
 
     // Clean up
     document.head.innerHTML = '';
+
+    await Promise.resolve();
 
     // Render again
     render(


### PR DESCRIPTION
> R1 老师教我写代码

## Benchmark
同时渲染 40000 个 Button，同一个组件，共用一份样式。

## 效果
benchmark 比较极端，正常不太会这么写页面，但可以看出能节省很多时间。
| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/e46aa61b-cced-4de1-89f4-0f78e8e1f692) | ![image](https://github.com/user-attachments/assets/b1d1d742-4bcf-423d-b8d7-60ac771a8ffb) |

## 原理
在之前的逻辑里每个 Button 渲染的时候都会执行 `updateCSS`，这个方法会在 document 里遍历 style 标签。
现在做了一个缓存 Map，同一份样式在一个微任务期间只会执行一次 `updateCSS`。



