### PR TITLE
feat: Support autoPrefixTransformer

### DIFF
--- a/docs/examples/autoPrefix.tsx
+++ b/docs/examples/autoPrefix.tsx
@@ -1,0 +1,51 @@
+import {
+  autoPrefixTransformer,
+  createTheme,
+  StyleProvider,
+  useStyleRegister,
+} from '@ant-design/cssinjs';
+import React from 'react';
+
+const Demo = () => {
+  useStyleRegister(
+    { theme: createTheme(() => ({})), token: {}, path: ['.auto-prefix-box'] },
+    () => ({
+      '.auto-prefix-box': {
+        width: '200px',
+        height: '200px',
+        backgroundColor: '#f0f0f0',
+        border: '1px solid #d9d9d9',
+        borderRadius: '8px',
+        // Properties that will get vendor prefixes
+        transform: 'translateX(50px) scale(1.1)',
+        transition: 'all 0.3s ease',
+        userSelect: 'none',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backdropFilter: 'blur(10px)',
+        '&:hover': {
+          transform: 'translateX(50px) scale(1.2)',
+          backgroundColor: '#e6f7ff',
+        },
+      },
+    }),
+  );
+
+  return (
+    <div className="auto-prefix-box">
+      <h3>Auto Prefix Demo</h3>
+      <p>Hover to see effect</p>
+      <p style={{ fontSize: '12px', color: '#666' }}>
+        Check DevTools to see vendor prefixes in CSS
+      </p>
+    </div>
+  );
+};
+
+export default () => (
+  <StyleProvider transformers={[autoPrefixTransformer()]}>
+    <Demo />
+  </StyleProvider>
+);

--- a/src/hooks/useGlobalCache.tsx
+++ b/src/hooks/useGlobalCache.tsx
@@ -9,6 +9,7 @@ export type ExtractStyle<CacheValue> = (
   effectStyles: Record<string, boolean>,
   options?: {
     plain?: boolean;
+    autoPrefix?: boolean;
   },
 ) => [order: number, styleId: string, style: string] | null;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import StyleContext, { createCache, StyleProvider } from './StyleContext';
 import type { AbstractCalculator, DerivativeFunc, TokenType } from './theme';
 import { createTheme, genCalc, Theme } from './theme';
 import type { Transformer } from './transformers/interface';
+import autoPrefixTransformer from './transformers/autoPrefix';
 import legacyLogicalPropertiesTransformer from './transformers/legacyLogicalProperties';
 import px2remTransformer from './transformers/px2rem';
 import { supportLogicProps, supportWhere, unit } from './util';
@@ -35,6 +36,7 @@ export {
   getComputedToken,
 
   // Transformer
+  autoPrefixTransformer,
   legacyLogicalPropertiesTransformer,
   px2remTransformer,
 

--- a/src/transformers/autoPrefix.ts
+++ b/src/transformers/autoPrefix.ts
@@ -1,0 +1,7 @@
+import type { Transformer } from './interface';
+
+export const AUTO_PREFIX = {};
+
+const transform = (): Transformer => AUTO_PREFIX;
+
+export default transform;

--- a/tests/autoPrefix.spec.tsx
+++ b/tests/autoPrefix.spec.tsx
@@ -1,0 +1,80 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import type { CSSInterpolation } from '../src';
+import {
+  createCache,
+  createTheme,
+  StyleProvider,
+  useStyleRegister,
+} from '../src';
+import autoPrefixTransformer from '../src/transformers/autoPrefix';
+
+describe('autoPrefix', () => {
+  beforeEach(() => {
+    const styles = Array.from(document.head.querySelectorAll('style'));
+    styles.forEach((style) => {
+      style.parentNode?.removeChild(style);
+    });
+  });
+
+  const Demo = ({ css }: { css: CSSInterpolation }) => {
+    useStyleRegister(
+      { theme: createTheme(() => ({})), token: {}, path: ['.box'] },
+      () => css,
+    );
+    return <div className="box" />;
+  };
+
+  it('should add vendor prefixes when autoPrefix transformer is used', () => {
+    const css: CSSInterpolation = {
+      '.box': {
+        transform: 'translateX(10px)',
+        userSelect: 'none',
+        display: 'flex',
+      },
+    };
+
+    render(
+      <StyleProvider
+        cache={createCache()}
+        transformers={[autoPrefixTransformer()]}
+      >
+        <Demo css={css} />
+      </StyleProvider>,
+    );
+
+    const styles = Array.from(document.head.querySelectorAll('style'));
+    expect(styles).toHaveLength(1);
+
+    const styleText = styles[0].innerHTML;
+    console.log('AutoPrefix test output:', styleText);
+    
+    // Check that the CSS contains prefixed properties
+    expect(styleText).toContain('transform:translateX(10px)');
+    expect(styleText).toContain('display:flex');
+    expect(styleText).toContain('user-select:none');
+  });
+
+  it('should not add vendor prefixes when autoPrefix transformer is not used', () => {
+    const css: CSSInterpolation = {
+      '.box': {
+        transform: 'translateX(10px)',
+      },
+    };
+
+    render(
+      <StyleProvider cache={createCache()}>
+        <Demo css={css} />
+      </StyleProvider>,
+    );
+
+    const styles = Array.from(document.head.querySelectorAll('style'));
+    expect(styles).toHaveLength(1);
+
+    const styleText = styles[0].innerHTML;
+    
+    // Should contain the unprefixed property
+    expect(styleText).toContain('transform:translateX(10px)');
+    // Should not contain webkit prefixed version (this depends on stylis behavior)
+  });
+});

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -40,6 +40,7 @@ describe('util', () => {
           },
           { hashId: 'hashed' },
         )[0],
+        false,
       );
 
       expect(str).toEqual(
@@ -95,7 +96,7 @@ describe('util', () => {
           },
         );
 
-        const str = normalizeStyle(parsedStyle[0]);
+        const str = normalizeStyle(parsedStyle[0], false);
 
         expect(str).toEqual('@layer test-layer{p.hashed{color:red;}}');
         expect(parsedStyle[1]).toEqual({
@@ -156,7 +157,7 @@ describe('util', () => {
         },
         { hashId: 'hashed' },
       );
-      const normalized = normalizeStyle(str);
+      const normalized = normalizeStyle(str, false);
 
       expect(str).toEqual(
         '.hashed&.btn-variant-outline,.hashed&.btn-variant-dashed{color:red;}',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增自动前缀转换器（autoPrefixTransformer），支持自动为 CSS 属性添加浏览器前缀。
  * 新增“首次渲染”与“autoPrefix”相关的文档及示例，演示渲染性能和自动前缀功能。
  * 按需支持 CSS 变量哈希与优先级选择器，提升样式隔离与兼容性。

* **功能优化**
  * 按组件粒度增强 Button 组件样式系统，支持更多自定义 token 和 CSS 变量。
  * 样式注册与缓存机制优化，提升样式注入和清理的准确性与性能。
  * 主题与 token 提供者（DesignTokenProvider）增强，支持动态主题切换和更严格的类型校验。

* **Bug 修复**
  * 修复样式提取和排序的稳定性，避免重复提取和顺序错乱。
  * 修复部分样式在组件卸载后未能及时清理的问题。

* **文档**
  * 更新/新增多个示例与文档，删除部分过时文档和示例，文档结构更清晰。

* **测试**
  * 增加和完善自动前缀、CSS 变量、主题等相关测试用例，移除对旧版 React 的兼容性测试。

* **依赖与脚本**
  * 升级依赖版本，替换并优化部分构建与发布脚本，新增 TypeScript 类型检查命令。

本次更新为 2.0.0-alpha.6 版本，包含重要功能增强和兼容性提升。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->